### PR TITLE
Add CNPG operator

### DIFF
--- a/agnostics/cnpg/base/kustomization.yaml
+++ b/agnostics/cnpg/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+
+configMapGenerator:
+  - name: cnpg-values
+    namespace: cnpg-system
+    literals:
+      - operatorVersion=cnpg-1.23.6.yaml
+      - targetRevision=release-1.23

--- a/agnostics/cnpg/base/namespace.yaml
+++ b/agnostics/cnpg/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-system

--- a/agnostics/cnpg/envs/dev/kustomization.yaml
+++ b/agnostics/cnpg/envs/dev/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: cnpg-values
+    namespace: cnpg-system
+    behavior: merge
+    literals:
+      - operatorVersion=cnpg-1.23.6.yaml
+      - targetRevision=release-1.23

--- a/agnostics/cnpg/envs/dev/values.json
+++ b/agnostics/cnpg/envs/dev/values.json
@@ -1,1 +1,0 @@
-{ "operatorVersion": "cnpg-1.23.6.yaml", "targetRevision": "release-1.23" }

--- a/agnostics/cnpg/envs/dev/values.json
+++ b/agnostics/cnpg/envs/dev/values.json
@@ -1,0 +1,1 @@
+{ "operatorVersion": "cnpg-1.23.6.yaml", "targetRevision": "release-1.23" }

--- a/agnostics/cnpg/envs/dev/values.yaml
+++ b/agnostics/cnpg/envs/dev/values.yaml
@@ -1,0 +1,3 @@
+cluster:
+  operatorVersion: cnpg-1.23.6.yaml
+  targetRevision: release-1.23

--- a/agnostics/cnpg/envs/dev/values.yaml
+++ b/agnostics/cnpg/envs/dev/values.yaml
@@ -1,0 +1,2 @@
+operatorVersion: cnpg-1.23.6.yaml
+targetRevision: release-1.23

--- a/agnostics/cnpg/envs/dev/values.yaml
+++ b/agnostics/cnpg/envs/dev/values.yaml
@@ -1,2 +1,0 @@
-operatorVersion: cnpg-1.23.6.yaml
-targetRevision: release-1.23

--- a/agnostics/cnpg/envs/prod/kustomization.yaml
+++ b/agnostics/cnpg/envs/prod/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# Create a values.yaml file for ArgoCD to consume
+# Production uses the same version of the operator
+configMapGenerator:
+  - name: cnpg-values
+    namespace: cnpg-system
+    behavior: merge
+    literals:
+      - operatorVersion=cnpg-1.23.6.yaml
+      - targetRevision=release-1.23

--- a/agnostics/cnpg/envs/prod/values.yaml
+++ b/agnostics/cnpg/envs/prod/values.yaml
@@ -1,0 +1,2 @@
+operatorVersion: cnpg-1.23.6.yaml
+targetRevision: release-1.23

--- a/agnostics/cnpg/envs/stg/kustomization.yaml
+++ b/agnostics/cnpg/envs/stg/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# Create a values.yaml file for ArgoCD to consume
+configMapGenerator:
+  - name: cnpg-values
+    namespace: cnpg-system
+    behavior: merge
+    literals:
+      - operatorVersion=cnpg-1.23.6.yaml
+      - targetRevision=release-1.23

--- a/agnostics/cnpg/envs/stg/values.yaml
+++ b/agnostics/cnpg/envs/stg/values.yaml
@@ -1,0 +1,2 @@
+operatorVersion: cnpg-1.23.6.yaml
+targetRevision: release-1.23

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -27,7 +27,7 @@ spec:
               selector:
                 matchLabels:
                   # This will match the environment from the path segment
-                  environment: "{{index .path.segments 3}}"
+                  environment: "{{ .environment | default (index .path.segments 3) }}"
 
   template:
     metadata:

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -11,7 +11,7 @@ spec:
 
   # Define how applications are discovered and generated
   generators:
-    - matrix:
+    - merge:
         generators:
           - git:
               # Repository containing the application definitions

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -25,7 +25,7 @@ spec:
                 - path: agnostics/cnpg/envs/*
               files:
                 # Load the environment-specific values file
-                - path: agnostics/cnpg/envs/*/values.json
+                - path: agnostics/cnpg/envs/*/values.yaml
           - clusters:
               selector:
                 matchLabels:
@@ -45,11 +45,11 @@ spec:
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
         # Use the targetRevision value from the environment-specific values file
-        targetRevision: "{{.targetRevision}}"
+        targetRevision: "{{.cluster.targetRevision}}"
         path: releases
         directory:
           # Use the operatorVersion value from the environment-specific values file
-          include: "{{.operatorVersion}}"
+          include: "{{.cluster.operatorVersion}}"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -11,18 +11,8 @@ spec:
 
   # Define how applications are discovered and generated
   generators:
-    - merge:
+    - matrix:
         generators:
-          - git:
-              # Repository containing the application definitions
-              repoURL: https://github.com/k8tre/k8tre.git
-              # Use HEAD to always track the latest commit on the default branch
-              revision: feature/vc-cnpg
-              # Pattern to match directories for app discovery
-              directories:
-                # Matches any directory under agnostics/cnpg/envs/
-                # e.g., agnostics/cnpg/envs/prod
-                - path: agnostics/cnpg/envs/*
           - git:
               # Repository containing the application definitions
               repoURL: https://github.com/k8tre/k8tre.git
@@ -32,11 +22,23 @@ spec:
                 # Load the environment-specific values file
                 - path: agnostics/cnpg/envs/*/values.yaml
               pathParamPrefix: config
-          - clusters:
-              selector:
-                matchLabels:
-                  # This will match the environment from the path segment
-                  environment: "{{index .path.segments 3}}"
+          - matrix:
+              generators:
+                - git:
+                    # Repository containing the application definitions
+                    repoURL: https://github.com/k8tre/k8tre.git
+                    # Use HEAD to always track the latest commit on the default branch
+                    revision: feature/vc-cnpg
+                    # Pattern to match directories for app discovery
+                    directories:
+                      # Matches any directory under agnostics/cnpg/envs/
+                      # e.g., agnostics/cnpg/envs/prod
+                      - path: agnostics/cnpg/envs/*
+                - clusters:
+                    selector:
+                      matchLabels:
+                        # This will match the environment from the path segment
+                        environment: "{{index .path.segments 3}}"
 
   template:
     metadata:

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -25,7 +25,7 @@ spec:
                 - path: agnostics/cnpg/envs/*
               files:
                 # Load the environment-specific values file
-                - path: agnostics/cnpg/envs/{{index .path.segments 3}}/values.yaml
+                - path: agnostics/cnpg/envs/*/values.yaml
           - clusters:
               selector:
                 matchLabels:
@@ -45,11 +45,11 @@ spec:
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
         # Use the targetRevision value from the environment-specific values file
-        targetRevision: "{{ if (hasKey .resources.values \"targetRevision\") }}{{ index .resources.values \"targetRevision\" }}{{ else }}release-1.23{{ end }}"
+        targetRevision: "{{.values.targetRevision}}"
         path: releases
         directory:
           # Use the operatorVersion value from the environment-specific values file
-          include: "{{ if (hasKey .resources.values \"operatorVersion\") }}{{ index .resources.values \"operatorVersion\" }}{{ else }}cnpg-1.23.6.yaml{{ end }}"
+          include: "{{.values.operatorVersion}}"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -18,35 +18,22 @@ spec:
               repoURL: https://github.com/k8tre/k8tre.git
               # Use HEAD to always track the latest commit on the default branch
               revision: feature/vc-cnpg
-              files:
-                # Load the environment-specific values file
-                - path: agnostics/cnpg/envs/*/values.yaml
-              pathParamPrefix: config
-          - matrix:
-              generators:
-                - git:
-                    # Repository containing the application definitions
-                    repoURL: https://github.com/k8tre/k8tre.git
-                    # Use HEAD to always track the latest commit on the default branch
-                    revision: feature/vc-cnpg
-                    # Pattern to match directories for app discovery
-                    directories:
-                      # Matches any directory under agnostics/cnpg/envs/
-                      # e.g., agnostics/cnpg/envs/prod
-                      - path: agnostics/cnpg/envs/*
-                    pathParamPrefix: env
-                - clusters:
-                    selector:
-                      matchLabels:
-                        # This will match the environment from the path segment
-                        environment: "{{index .env.path.segments 3}}"
-
+              # Pattern to match directories for app discovery
+              directories:
+                # Matches any directory under agnostics/cnpg/envs/
+                # e.g., agnostics/cnpg/envs/prod
+                - path: agnostics/cnpg/envs/*
+          - clusters:
+              selector:
+                matchLabels:
+                  # This will match the environment from the path segment
+                  environment: "{{index .path.segments 3}}"
   template:
     metadata:
-      name: "{{index .env.path.segments 1}}"
+      name: "{{index .path.segments 1}}"
       annotations:
         # ArgoCD application name
-        argocd.argoproj.io/instance: "{{index .path.segments 1}}-{{index .env.path.segments 3}}"
+        argocd.argoproj.io/instance: "{{index .path.segments 1}}-{{index .path.segments 3}}"
         # Sync wave to control the order of application sync
         argocd.argoproj.io/sync-wave: "-10"
     spec:
@@ -54,11 +41,11 @@ spec:
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
         # Use the targetRevision value from the environment-specific values file
-        targetRevision: "{{.config.cluster.targetRevision}}"
+        targetRevision: "release-1.23"
         path: releases
         directory:
           # Use the operatorVersion value from the environment-specific values file
-          include: "{{.config.cluster.operatorVersion}}"
+          include: "cnpg-1.23.6.yaml"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -34,18 +34,19 @@ spec:
                       # Matches any directory under agnostics/cnpg/envs/
                       # e.g., agnostics/cnpg/envs/prod
                       - path: agnostics/cnpg/envs/*
+                    pathParamPrefix: env
                 - clusters:
                     selector:
                       matchLabels:
                         # This will match the environment from the path segment
-                        environment: "{{index .path.segments 3}}"
+                        environment: "{{index .env.path.segments 3}}"
 
   template:
     metadata:
-      name: "{{index .path.segments 1}}"
+      name: "{{index .env.path.segments 1}}"
       annotations:
         # ArgoCD application name
-        argocd.argoproj.io/instance: "{{index .path.segments 1}}-{{index .path.segments 3}}"
+        argocd.argoproj.io/instance: "{{index .path.segments 1}}-{{index .env.path.segments 3}}"
         # Sync wave to control the order of application sync
         argocd.argoproj.io/sync-wave: "-10"
     spec:

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -23,9 +23,15 @@ spec:
                 # Matches any directory under agnostics/cnpg/envs/
                 # e.g., agnostics/cnpg/envs/prod
                 - path: agnostics/cnpg/envs/*
+          - git:
+              # Repository containing the application definitions
+              repoURL: https://github.com/k8tre/k8tre.git
+              # Use HEAD to always track the latest commit on the default branch
+              revision: feature/vc-cnpg
               files:
                 # Load the environment-specific values file
                 - path: agnostics/cnpg/envs/*/values.yaml
+              pathParamPrefix: config
           - clusters:
               selector:
                 matchLabels:
@@ -45,11 +51,11 @@ spec:
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
         # Use the targetRevision value from the environment-specific values file
-        targetRevision: "{{.cluster.targetRevision}}"
+        targetRevision: "{{.config.cluster.targetRevision}}"
         path: releases
         directory:
           # Use the operatorVersion value from the environment-specific values file
-          include: "{{.cluster.operatorVersion}}"
+          include: "{{.config.cluster.operatorVersion}}"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -17,7 +17,7 @@ spec:
               # Repository containing the application definitions
               repoURL: https://github.com/k8tre/k8tre.git
               # Use HEAD to always track the latest commit on the default branch
-              revision: main
+              revision: '{{ .revision | default "main" }}'
               # Pattern to match directories for app discovery
               directories:
                 # Matches any directory under agnostics/cnpg/envs/

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -16,13 +16,17 @@ spec:
           - git:
               # Repository containing the application definitions
               repoURL: https://github.com/k8tre/k8tre.git
-              # Use HEAD to always track the latest commit on the default branch
+              # Use feature branch for testing
               revision: feature/vc-cnpg
               # Pattern to match directories for app discovery
               directories:
                 # Matches any directory under agnostics/cnpg/envs/
                 # e.g., agnostics/cnpg/envs/prod
                 - path: agnostics/cnpg/envs/*
+              files:
+                # Create environment-specific values files that will be used to configure deployments
+                - path: agnostics/cnpg/envs/{{index .path.segments 3}}/values.yaml
+                  name: values
           - clusters:
               selector:
                 matchLabels:
@@ -36,17 +40,17 @@ spec:
         # ArgoCD application name
         argocd.argoproj.io/instance: "{{index .path.segments 1}}-{{index .path.segments 3}}"
         # Sync wave to control the order of application sync
-        # Lower numbers are synced first
-        # This is set to -10 to ensure it syncs before other applications
         argocd.argoproj.io/sync-wave: "-10"
     spec:
       project: default
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
-        targetRevision: '{{.values.targetRevision | default "release-1.23"}}'
+        # Use the targetRevision value from the environment-specific values file
+        targetRevision: "{{ if (index .values).targetRevision }}{{ (index .values).targetRevision }}{{ else }}release-1.23{{ end }}"
         path: releases
         directory:
-          include: '{{.values.operatorVersion | default "cnpg-1.23.6.yaml"}}'
+          # Use the operatorVersion value from the environment-specific values file
+          include: "{{ if (index .values).operatorVersion }}{{ (index .values).operatorVersion }}{{ else }}cnpg-1.23.6.yaml{{ end }}"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -1,0 +1,58 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cnpg
+  namespace: argocd
+spec:
+  # Enable Go templating for dynamic field generation
+  goTemplate: true
+  # Configure template behavior - fail if a key is missing
+  goTemplateOptions: ["missingkey=error"]
+
+  # Define how applications are discovered and generated
+  generators:
+    - matrix:
+        generators:
+          - git:
+              # Repository containing the application definitions
+              repoURL: https://github.com/k8tre/k8tre.git
+              # Use HEAD to always track the latest commit on the default branch
+              revision: main
+              # Pattern to match directories for app discovery
+              directories:
+                # Matches any directory under agnostics/cnpg/envs/
+                # e.g., agnostics/cnpg/envs/prod
+                - path: agnostics/cnpg/envs/*
+          - clusters:
+              selector:
+                matchLabels:
+                  # This will match the environment from the path segment
+                  environment: "{{index .path.segments 3}}"
+
+  template:
+    metadata:
+      name: "{{index .path.segments 1}}"
+      annotations:
+        # ArgoCD application name
+        argocd.argoproj.io/instance: "{{index .path.segments 1}}-{{index .path.segments 3}}"
+        # Sync wave to control the order of application sync
+        # Lower numbers are synced first
+        # This is set to -10 to ensure it syncs before other applications
+        argocd.argoproj.io/sync-wave: "-10"
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/cloudnative-pg/cloudnative-pg
+        targetRevision: '{{.values.targetRevision | default "release-1.23"}}'
+        path: releases
+        directory:
+          include: '{{.values.operatorVersion | default "cnpg-1.23.6.yaml"}}'
+      destination:
+        server: "{{.server}}"
+        namespace: cnpg-system
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -17,7 +17,7 @@ spec:
               # Repository containing the application definitions
               repoURL: https://github.com/k8tre/k8tre.git
               # Use HEAD to always track the latest commit on the default branch
-              revision: '{{ .revision | default "main" }}'
+              revision: feature/vc-cnpg
               # Pattern to match directories for app discovery
               directories:
                 # Matches any directory under agnostics/cnpg/envs/

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -25,7 +25,7 @@ spec:
                 - path: agnostics/cnpg/envs/*
               files:
                 # Load the environment-specific values file
-                - path: agnostics/cnpg/envs/*/values.yaml
+                - path: agnostics/cnpg/envs/*/values.json
           - clusters:
               selector:
                 matchLabels:

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -27,7 +27,7 @@ spec:
               selector:
                 matchLabels:
                   # This will match the environment from the path segment
-                  environment: "{{ .environment | default (index .path.segments 3) }}"
+                  environment: "{{index .path.segments 3}}"
 
   template:
     metadata:

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -16,7 +16,7 @@ spec:
           - git:
               # Repository containing the application definitions
               repoURL: https://github.com/k8tre/k8tre.git
-              # Use feature branch for testing
+              # Use HEAD to always track the latest commit on the default branch
               revision: feature/vc-cnpg
               # Pattern to match directories for app discovery
               directories:
@@ -24,9 +24,8 @@ spec:
                 # e.g., agnostics/cnpg/envs/prod
                 - path: agnostics/cnpg/envs/*
               files:
-                # Create environment-specific values files that will be used to configure deployments
+                # Load the environment-specific values file
                 - path: agnostics/cnpg/envs/{{index .path.segments 3}}/values.yaml
-                  name: values
           - clusters:
               selector:
                 matchLabels:
@@ -46,11 +45,11 @@ spec:
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
         # Use the targetRevision value from the environment-specific values file
-        targetRevision: "{{ if (index .values).targetRevision }}{{ (index .values).targetRevision }}{{ else }}release-1.23{{ end }}"
+        targetRevision: "{{ if (hasKey .resources.values \"targetRevision\") }}{{ index .resources.values \"targetRevision\" }}{{ else }}release-1.23{{ end }}"
         path: releases
         directory:
           # Use the operatorVersion value from the environment-specific values file
-          include: "{{ if (index .values).operatorVersion }}{{ (index .values).operatorVersion }}{{ else }}cnpg-1.23.6.yaml{{ end }}"
+          include: "{{ if (hasKey .resources.values \"operatorVersion\") }}{{ index .resources.values \"operatorVersion\" }}{{ else }}cnpg-1.23.6.yaml{{ end }}"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -45,11 +45,11 @@ spec:
       source:
         repoURL: https://github.com/cloudnative-pg/cloudnative-pg
         # Use the targetRevision value from the environment-specific values file
-        targetRevision: "{{.values.targetRevision}}"
+        targetRevision: "{{.targetRevision}}"
         path: releases
         directory:
           # Use the operatorVersion value from the environment-specific values file
-          include: "{{.values.operatorVersion}}"
+          include: "{{.operatorVersion}}"
       destination:
         server: "{{.server}}"
         namespace: cnpg-system

--- a/appsets/agnostics/cnpg.yaml
+++ b/appsets/agnostics/cnpg.yaml
@@ -55,3 +55,4 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+          - ServerSideApply=true # https://github.com/cloudnative-pg/charts/issues/325


### PR DESCRIPTION
This PR adds the [CNPG operator](https://cloudnative-pg.io/) to all target clusters. No databases are provisioned as part of this but the operator allows provisioning postgres databases in a k8s native manner.
