### PR TITLE
Add initial GitHub CI tests for K3S

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,76 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  # pre-commit:
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #     - uses: pre-commit/action@v3.0.1
+
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: dev-requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r dev-requirements.txt
+
+      - name: Install deployment
+        run: |
+          ./ci/run_codeblocks.py docs/development/k3s-dev.md --run
+
+      - name: Run tests
+        run: |
+          python -mpytest -v --color=yes
+
+      - name: Get logs, including on failure
+        if: always()
+        run: |
+          echo "::group::argocd-server"
+          kubectl -nargocd logs deploy/argocd-server
+          echo "::endgroup::"
+
+      - name: Get ArgoCD apps, including on failure
+        if: always()
+        run: |
+          for kind in appprojects applicationsets applications; do
+            echo "::group::argocd $kind"
+            kubectl describe $kind -A
+            echo "::endgroup::"
+          done
+
+  # Set a single status check for the whole workflow, so that we can use it in a
+  # branch protection rule
+  status-check:
+    runs-on: ubuntu-24.04
+    needs:
+      # - pre-commit
+      - test
+    if: always()
+    steps:
+      - name: Get job statuses
+        uses: technote-space/workflow-conclusion-action@v3.0.3
+        with:
+          FALLBACK_CONCLUSION: failure
+          STRICT_SUCCESS: true
+        # Status is saved in env.WORKFLOW_CONCLUSION
+
+      - name: Status check
+        if: env.WORKFLOW_CONCLUSION != 'success'
+        run: |
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # K8TRE - SATRE-Compliant TRE implementation on Kubernetes
 
+[![Test](https://github.com/k8tre/k8tre/actions/workflows/test.yaml/badge.svg)](https://github.com/k8tre/k8tre/actions/workflows/test.yaml)
+
 Welcome to K8TRE! 
 
 This is part of a DARE-UK funded project to build a community around an open-source, SATRE-compliant TRE on Kubernetes. 

--- a/ci/run_codeblocks.py
+++ b/ci/run_codeblocks.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Extract and run fenced codeblocks from a markdown file
+
+from argparse import ArgumentParser
+from os import getenv
+from subprocess import run
+
+CI = getenv("CI") == "true"
+
+parser = ArgumentParser(description="Extract fenced codeblocks from a markdown file")
+parser.add_argument("input", help="Input markdown file")
+parser.add_argument(
+    "--sub",
+    action="append",
+    default=[],
+    help="Substitute a string in the input file (string=replacement)",
+)
+parser.add_argument("--run", action="store_true", help="Run the code")
+
+args = parser.parse_args()
+
+scripts = []
+inside_code = False
+script = []
+n = 0
+with open(args.input) as f:
+    for line in f:
+        n += 1
+        if line.startswith("```"):
+            if line[3:].rstrip() not in ("", "bash"):
+                raise ValueError(
+                    f"Line {n}: Only bash code blocks are supported: {line}"
+                )
+            inside_code = not inside_code
+            if not inside_code:
+                scripts.append("".join(script))
+                script = []
+        elif inside_code:
+            for sub in args.sub:
+                find, replace = sub.split("=", 1)
+                line = line.replace(find, replace)
+            script.append(line)
+
+if script:
+    raise ValueError(f"Line {n}: Incomplete script: Missing closing ```")
+
+for s in scripts:
+    if CI:
+        firstline = s.strip().splitlines()[0]
+        print(f"::group::{firstline}")
+
+    print(f"Running\n```\n{s}\n```", flush=True)
+    if args.run:
+        run(["bash", "-o", "errexit", "-o", "xtrace", "-c", s], check=True)
+
+    if CI:
+        print("::endgroup::")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+kubernetes==32.0.1
+pytest==8.3.5

--- a/docs/development/k3s-dev.md
+++ b/docs/development/k3s-dev.md
@@ -1,0 +1,159 @@
+# Setting up K3s all-in-one Development Environment
+
+This documentation guides you through creating an all-in-one development environment using a single K3s cluster (ArgoCD is deployment in the same cluster as a K8TRE dev deployment).
+
+These instructions are also used for automatically testing K8TRE in [GitHub actions](https://github.com/k8tre/k8tre/actions/workflows/test.yaml).
+For more hands-on instructions with explanations see [k3s.md](k3s.md).
+
+## Prerequisites
+
+This assumes you already have a [Ubuntu 24.04](https://ubuntu.com/download/desktop) virtual machine.
+
+## Configure and install K3s
+
+Create a K3s configuration file, then install K3S.
+Although most commands can be passed to the command line installer it is more convenient to define them in a [K3S configuration file](https://docs.k3s.io/installation/configuration#configuration-file).
+
+```bash
+sudo mkdir -p /etc/rancher/k3s
+sudo tee /etc/rancher/k3s/config.yaml << EOF
+node-name: k8tre-dev
+tls-san:
+  - k8tre-dev
+cluster-init: true
+EOF
+
+curl -sfSL https://get.k3s.io | INSTALL_K3S_VERSION=v1.32.4+k3s1 sh -
+```
+
+Setup Kubeconfig file
+
+```bash
+mkdir -p ~/.kube
+sudo cat /etc/rancher/k3s/k3s.yaml > ~/.kube/config
+```
+
+### 3.2 Enable Required Add-ons
+
+Enable MetalLB and hostpath-storage on both VMs:
+
+```bash
+# kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+# kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+# kubectl apply -f https://raw.githubusercontent.com/helm/charts/master/stable/hostpath-provisioner/hostpath-provisioner.yaml
+
+# # For MetalLB, provide an IP address range (adjust based on your network)
+# kubectl patch configmap config -n metallb-system --type merge -p '{"data": {"config": "address-pools:\n- name: default\n  protocol: layer2\n  addresses:\n  - 192.168.123.50-192.168.123.100\n"}}'
+```
+
+
+## Setup ArgoCD
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.14.11/manifests/install.yaml
+sleep 10
+kubectl wait --for=condition=Ready pods --all -n argocd --timeout=300s
+```
+
+Install ArgoCD CLI
+
+```bash
+sudo curl -sfSL https://github.com/argoproj/argo-cd/releases/download/v2.14.11/argocd-linux-amd64 -o /usr/local/bin/argocd
+sudo chmod a+x /usr/local/bin/argocd
+```
+
+Configure ArgoCD
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443 --address 0.0.0.0 &
+sleep 1
+
+# Get the initial admin password
+ARGOCD_PASSWORD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+
+# Login, disable certificate validation
+argocd login localhost:8080 --username=admin --password="$ARGOCD_PASSWORD" --insecure
+```
+
+
+Mark the current cluster as the ArgoCD dev environment
+
+```bash
+argocd cluster set in-cluster --label environment=dev
+argocd cluster get in-cluster
+```
+
+Configure ArgoCD for Kustomize Helm Overlays by applying a ConfigMap patch:
+
+```bash
+cat << EOF > argocd-cm-patch.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  kustomize.buildOptions: "--enable-helm --load-restrictor LoadRestrictionsNone"
+EOF
+
+kubectl apply -f argocd-cm-patch.yaml
+```
+
+Restart the ArgoCD repo server to apply changes:
+
+```bash
+kubectl rollout restart deployment argocd-repo-server -n argocd
+```
+
+List CRDs
+```bash
+kubectl get crd
+```
+
+## Deploy the app-of-apps
+
+Edit the app-of-apps to point to you GitHub fork `$GITHUB_REPOSITORY` and branch/commit `$GITHUB_SHA`
+
+```bash
+sed -i -e "s%/k8tre/k8tre%/${GITHUB_REPOSITORY}%" -e "s%main%${GITHUB_SHA}%" app_of_apps/root-app-of-apps.yaml
+git diff
+```
+
+Deploy the app-of-apps
+```bash
+kubectl apply -f app_of_apps/root-app-of-apps.yaml
+```
+
+Wait for app-of-apps to be created
+```bash
+sleep 60
+kubectl -nargocd wait --for=jsonpath='{.status.health.status}'=Healthy application root-app-of-apps --timeout=300s
+```
+
+```bash
+kubectl get appprojects -A
+kubectl get applicationsets -A
+kubectl get applications -A
+```
+
+Wait for applications in app-of-apps to be created
+```bash
+kubectl -nargocd wait --for=jsonpath='{.status.health.status}'=Healthy application --all --timeout=300s
+```
+
+```bash
+kubectl get deployment -A
+kubectl get daemonset -A
+kubectl get crd
+```
+
+TODO:
+- Check all references to `k8tre/k8tre` and `main` are changed in all applications
+- Check number of applications is as expected
+- Check all applications are synchronised
+- Check deployments/daemonsets etc are healthy and ready
+- Playright test to login and launch workspace

--- a/tests/test_argocd.py
+++ b/tests/test_argocd.py
@@ -1,0 +1,42 @@
+import kubernetes
+import json
+import os
+import pytest
+
+kubernetes.config.load_config()
+
+
+def get_applications():
+    crd_api = kubernetes.client.CustomObjectsApi()
+    apps = crd_api.list_cluster_custom_object("argoproj.io", "v1alpha1", "applications")
+    return apps["items"]
+
+
+def application_id_fn(app):
+    return f"{app['metadata']['namespace']}/{app['metadata']['name']}"
+
+
+@pytest.mark.parametrize("app", get_applications(), ids=application_id_fn)
+def test_argocd_application_repos(app):
+    """
+    Check that repoURL and targetRevision has been changed so that we've
+    deployed the fork/branch when testing in CI
+
+    If running in GitHub CI then either repoURL is not k8tre, or repoURL and
+    targetRevision match GITHUB_REPOSITORY and GITHUB_SHA
+    """
+    repo = os.getenv("GITHUB_REPOSITORY")
+    sha = os.getenv("GITHUB_SHA")
+
+    # https://argo-cd.readthedocs.io/en/latest/user-guide/application-specification/
+    sources = []
+    s = app["spec"].get("source")
+    if s:
+        sources.append(s)
+    sources.extend(app["spec"].get("sources", []))
+
+    for s in sources:
+        print(json.dumps(s, indent=2))
+        if s and "k8tre" in s["repoURL"]:
+            assert s["repoURL"].removesuffix(".git") == f"https://github.com/{repo}"
+            assert s["targetRevision"] == sha


### PR DESCRIPTION
This adds some very basic GitHub CI tests for K8TRE:
- Adds a new K3s dev page which contains code blocks that are autoamtically run in GitHub CI
- Checks that ArgoCD Application repoURL and branches are updated to point to the branch being tested, not k8tre/k8tre main

So far this is only very basic stuff, but we can add to it in future. E.g. we could add [Playright](https://playwright.dev/python/docs/intro) browser tests to check we can login and spin up a workspace, and run some network checks to verify egress is blocked from inside the workspace.