### PR TITLE
Add ci script to create Keycloak client and example user for JupyterHub

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,16 @@ jobs:
         run: |
           pip install -r dev-requirements.txt
 
+      - name: Modify hosts to resolve k8tre.internal URLs
+        run: |
+          h=$(grep "$(hostname -i) " /etc/hosts)
+          if [ -n "$h" ]; then
+            sudo sed -i -re "s/$h/$h jupyter.dev.k8tre.internal keycloak.dev.k8tre.internal/" /etc/hosts
+          else
+            echo $(hostname -i) {jupyter,keycloak}.dev.k8tre.internal | sudo tee -a /etc/hosts
+          fi
+          cat /etc/hosts
+
       - name: Install deployment
         run: |
           ./ci/run_codeblocks.py docs/development/k3s-dev.md --run

--- a/apps/jupyterhub/base/network_policy.yaml
+++ b/apps/jupyterhub/base/network_policy.yaml
@@ -41,3 +41,26 @@ spec:
       app: jupyterhub
       component: continuous-image-puller
 
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-access-hub-to-keycloak
+  namespace: jupyterhub
+spec:
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: keycloak
+            app.kubernetes.io/component: keycloak
+            app.kubernetes.io/instance: keycloak
+            app.kubernetes.io/name: keycloak
+      toPorts:
+        - ports:
+            # This is the pod not the service port
+            - port: "8080"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app: jupyterhub
+      component: hub

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -8,10 +8,39 @@ hub:
           - port: 6443
           - port: 443
   config:
+    Authenticator:
+      enable_auth_state: true
+    # Lookup URLs from
+    # https://<keycloak-url>/realms/<realm>/.well-known/openid-configuration
+    GenericOAuthenticator:
+      client_id: jupyterhub
+      client_secret: jupyterhub-client-secret
+      oauth_callback_url: https://jupyter.dev.k8tre.internal/hub/oauth_callback
+      authorize_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/auth
+      token_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/token
+      userdata_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/userinfo
+      scope:
+        - openid
+        # The custom scope name
+        - jupyterhub-roles
+      login_service: keycloak
+      username_key: preferred_username
+      userdata_params:
+        state: state
+      # The location of the custom Keycloak field in the userdata response
+      auth_state_groups_key: oauth_user.jupyterhub.roles
+      # JupyterHub defers to Keycloak for all group memberships
+      manage_groups: true
+      allowed_groups:
+        # The Keycloak role for JupyterHub users
+        - jupyterhub-users
+      admin_groups:
+        # The Keycloak role for JupyterHub admins
+        - jupyterhub-admins
+      # For CI testing only with self-signed certificates!
+      validate_server_cert: false
     JupyterHub:
-      admin_access: true
-      admin_users:
-        - admin
+      authenticator_class: generic-oauth
 proxy:
   service:
     type: ClusterIP

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -15,10 +15,12 @@ hub:
     GenericOAuthenticator:
       client_id: jupyterhub
       client_secret: jupyterhub-client-secret
+      # Accessed externally by the user
       oauth_callback_url: https://jupyter.dev.k8tre.internal/hub/oauth_callback
       authorize_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/auth
-      token_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/token
-      userdata_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/userinfo
+      # Internal to the cluster: svc=keycloak ns=keycloak
+      token_url: http://keycloak.keycloak/realms/master/protocol/openid-connect/token
+      userdata_url: http://keycloak.keycloak/realms/master/protocol/openid-connect/userinfo
       scope:
         - openid
         # The custom scope name

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -24,21 +24,21 @@ hub:
       scope:
         - openid
         # The custom scope name
-        - jupyterhub-roles
+        - k8tre-roles
       login_service: keycloak
       username_key: preferred_username
       userdata_params:
         state: state
       # The location of the custom Keycloak field in the userdata response
-      auth_state_groups_key: oauth_user.jupyterhub.roles
+      auth_state_groups_key: oauth_user.k8tre.roles
       # JupyterHub defers to Keycloak for all group memberships
       manage_groups: true
       allowed_groups:
         # The Keycloak role for JupyterHub users
-        - jupyterhub-users
+        - k8tre-users
       admin_groups:
         # The Keycloak role for JupyterHub admins
-        - jupyterhub-admins
+        - k8tre-admins
       # For CI testing only with self-signed certificates!
       validate_server_cert: false
     JupyterHub:

--- a/ci/ci-setup-keycloak.py
+++ b/ci/ci-setup-keycloak.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+# coding: utf-8
+# https://github.com/marcospereirampj/python-keycloak
+from argparse import ArgumentParser
+import json
+from keycloak import KeycloakAdmin
+import sys
+
+parser = ArgumentParser()
+parser.add_argument(
+    "--keycloak-url", default="https://keycloak.dev.k8tre.internal", help="Keycloak URL"
+)
+parser.add_argument(
+    "--jupyterhub-url",
+    default="https://jupyter.dev.k8tre.internal",
+    help="JupyterHub URL",
+)
+parser.add_argument("--keycloak-admin", default="admin", help="Keycloak admin user")
+parser.add_argument(
+    "--keycloak-password", default="admin", help="Keycloak admin password"
+)
+parser.add_argument(
+    "--user", default="example@example.com", help="Username of new user"
+)
+parser.add_argument("--password", default="secret", help="Password for new user")
+parser.add_argument("--firstname", default="Example", help="First name of new user")
+parser.add_argument("--lastname", default="User", help="Last name of new user")
+parser.add_argument(
+    "--client-name", default="jupyterhub", help="JupyterHub OAuth client name"
+)
+parser.add_argument(
+    "--client-secret",
+    default="jupyterhub-client-secret",
+    help="JupyterHub OAuth client secret",
+)
+parser.add_argument(
+    "--admin-role",
+    default="jupyterhub-admins",
+    help="Name of JupyterHub Keycloak admin role",
+)
+parser.add_argument(
+    "--user-role",
+    default="jupyterhub-users",
+    help="Name of JupyterHub Keycloak user role",
+)
+parser.add_argument(
+    "--scope-name",
+    default="jupyterhub-roles",
+    help="Custom scope name to use for JupyterHub Keycloak roles",
+)
+parser.add_argument(
+    "--verify",
+    default="true",
+    help="Set to the path to a CA, or 'false' to disable SSL verification, default is to use system CA",
+)
+
+
+args = parser.parse_args()
+
+
+def output(firstline, message=None):
+    if sys.stdout.isatty():
+        # Bold green text
+        print(f"\033[1m\033[32m{firstline}\033[97m\033[0m")
+    else:
+        print(firstline)
+    if message is not None:
+        print(json.dumps(message, indent=2))
+
+
+jupyterhub_url = args.jupyterhub_url
+
+verify = args.verify
+if verify.lower() == "true":
+    verify = True
+if verify.lower() == "false":
+    verify = False
+
+keycloak_admin = KeycloakAdmin(
+    server_url=args.keycloak_url,
+    username=args.keycloak_admin,
+    password=args.keycloak_password,
+    realm_name="master",
+    verify=verify,
+)
+
+# Create a user
+user_payload = {
+    "email": args.user,
+    "username": args.user,
+    "enabled": True,
+    "firstName": args.firstname,
+    "lastName": args.lastname,
+    "credentials": [
+        {
+            "value": args.password,
+            "type": "password",
+        }
+    ],
+}
+uid = keycloak_admin.get_user_id(args.user)
+if uid:
+    output(f"Updating user {args.user} ({uid})", user_payload)
+    keycloak_admin.update_user(uid, user_payload)
+else:
+    output(f"Creating user {args.user}", user_payload)
+    keycloak_admin.create_user(user_payload)
+
+# Create an OAuth client for JupyterHub
+client_payload = {
+    "clientId": args.client_name,
+    "name": args.client_name,
+    "rootUrl": args.jupyterhub_url.rstrip("/"),
+    "baseUrl": "/",
+    "redirectUris": ["/hub/oauth_callback"],
+    "clientAuthenticatorType": "client-secret",
+    "secret": args.client_secret,
+}
+cid = keycloak_admin.get_client_id(args.client_name)
+if cid:
+    output(f"Updating client {args.client_name} ({cid})", client_payload)
+    keycloak_admin.update_client(cid, client_payload)
+else:
+    output(f"Creating client {args.client_name}", client_payload)
+    cid = keycloak_admin.create_client(client_payload)
+# print(keycloak_admin.get_client(cid))
+
+# Create some client specific roles (you could also create realm roles that can be used by multiple clients)
+client_role_admins_payload = {
+    "name": args.admin_role,
+    "description": "JupyterHub admins",
+}
+output(f"Creating/updating client role {args.admin_role}", client_role_admins_payload)
+keycloak_admin.create_client_role(cid, client_role_admins_payload, skip_exists=True)
+client_role_users_payload = {
+    "name": args.user_role,
+    "description": "JupyterHub users",
+}
+output(f"Creating/updating client role {args.user_role}", client_role_users_payload)
+keycloak_admin.create_client_role(cid, client_role_users_payload, skip_exists=True)
+
+# Create or update a custom scope called "jupyterhub-groups" that maps Keycloak client Roles
+scope = {
+    "name": args.scope_name,
+    "description": "JupyterHub Keycloak roles",
+    "protocol": "openid-connect",
+    "protocolMappers": [
+        {
+            "name": args.scope_name,
+            "protocol": "openid-connect",
+            # Map client roles:
+            "protocolMapper": "oidc-usermodel-client-role-mapper",
+            # Map realm roles:
+            # "protocolMapper": "oidc-usermodel-realm-role-mapper",
+            # Map Keycloak groups:
+            # "protocolMapper": "oidc-group-membership-mapper",
+            "config": {
+                "multivalued": "true",
+                # Include in the userinfo response
+                "userinfo.token.claim": "true",
+                # The userinfo field
+                "claim.name": "jupyterhub.roles",
+                "jsonType.label": "String",
+                # Only return client scopes for jupyterhub
+                "usermodel.clientRoleMapping.clientId": args.client_name,
+            },
+        }
+    ],
+}
+output(f"Creating or updating scope {args.scope_name}", scope)
+scope_id = keycloak_admin.create_client_scope(scope, skip_exists=True)
+keycloak_admin.update_client_scope(scope_id, scope)
+
+# Add scope to client
+keycloak_admin.add_client_optional_client_scope(cid, scope_id, {})
+
+# Assign users to client roles
+client_admin_role = keycloak_admin.get_client_role(cid, args.admin_role)
+client_user_role = keycloak_admin.get_client_role(cid, args.user_role)
+
+admin_uid = keycloak_admin.get_user_id(args.keycloak_admin)
+output(
+    f"Assigning roles to admin {args.keycloak_admin} ({admin_uid})",
+    [client_admin_role, client_user_role],
+)
+keycloak_admin.assign_client_role(admin_uid, cid, [client_admin_role, client_user_role])
+
+user_uid = keycloak_admin.get_user_id(args.user)
+output(f"Assigning roles to user {args.user} ({user_uid})", client_user_role)
+keycloak_admin.assign_client_role(user_uid, cid, [client_user_role])

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 kubernetes==32.0.1
 pytest==8.3.5
+python-keycloak==5.6.0
+requests==2.32.4

--- a/docs/development/k3s-dev.md
+++ b/docs/development/k3s-dev.md
@@ -191,6 +191,20 @@ kubectl get daemonset -A
 kubectl get crd
 ```
 
+## Setup Keycloak
+
+
+```bash
+# Get the initial admin password
+KEYCLOAK_PASSWORD=$(kubectl -nkeycloak get secret keycloak -o jsonpath='{.data.admin-password}' | base64 -d)
+
+ci/ci-setup-keycloak.py \
+  --keycloak-admin=user \
+  --keycloak-password="$KEYCLOAK_PASSWORD" \
+  --verify=false
+```
+
+
 TODO:
 - Check all references to `k8tre/k8tre` and `main` are changed in all applications
 - Check number of applications is as expected


### PR DESCRIPTION
Configure the dev JupyterHub with OAuthenticator and Keycloak.

There are an infinite number of ways to configure Keycloak users, groups, roles and scopes. I've copied the config from https://github.com/manics/zero-to-jupyterhub-k8s-examples/tree/2e6342a49c75a4571d83278d121d9e9d7922c246/keycloak simply because it works, but using realm roles instead of client roles (though we should discuss which is best).

The script uses the Keycloak API to create:
- User with username `example@example.com`, password `secret`
- JupyterHub OAuth client and scope
- Two _roles_, ~`jupyterhub-admins`~`k8tre-admins` and ~`jupyterhub-users`~`k8tre-users`
- Assigns `example@example.com` to ~`jupyterhub-users`~`k8tre-users`
- Assigns the current keycloak admin to ~`jupyterhub-admins`~`k8tre-admins` and ~`jupyterhub-users`~`k8tre-users`

Note the default Keycloak admin user created by the Keycloak Helm chart is called `user`, I think we should change it to `admin` to make it clearer this is an admin user but that can be done in a separate PR.