### PR TITLE
Add Guacamole and configure JupyterHub to launch containerised Ubuntu MATE desktops

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,7 @@ jobs:
     timeout-minutes: 20
 
     env:
-      JUPYTERHUB_HOST: jupyter.k8tre.internal
-      KEYCLOAK_HOST: keycloak.k8tre.internal
+      K8TRE_DOMAIN: dev.k8tre.internal
 
     steps:
 
@@ -49,11 +48,12 @@ jobs:
 
       - name: Modify hosts to resolve k8tre.internal URLs
         run: |
+          K8TRE_SUBDOMAINS="jupyter.$K8TRE_DOMAIN keycloak.$K8TRE_DOMAIN"
           h=$(grep "$(hostname -i) " /etc/hosts)
           if [ -n "$h" ]; then
-            sudo sed -i -re "s/$h/$h $JUPYTERHUB_HOST $KEYCLOAK_HOST/" /etc/hosts
+            sudo sed -i -re "s/$h/$h $K8TRE_SUBDOMAINS/" /etc/hosts
           else
-            echo $(hostname -i) $JUPYTERHUB_HOST $KEYCLOAK_HOST | sudo tee -a /etc/hosts
+            echo $(hostname -i) $K8TRE_SUBDOMAINS | sudo tee -a /etc/hosts
           fi
           cat /etc/hosts
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 
+    env:
+      JUPYTERHUB_HOST: jupyter.k8tre.internal
+      KEYCLOAK_HOST: keycloak.k8tre.internal
+
     steps:
       - uses: actions/checkout@v4
 
@@ -41,9 +45,9 @@ jobs:
         run: |
           h=$(grep "$(hostname -i) " /etc/hosts)
           if [ -n "$h" ]; then
-            sudo sed -i -re "s/$h/$h jupyter.dev.k8tre.internal keycloak.dev.k8tre.internal/" /etc/hosts
+            sudo sed -i -re "s/$h/$h $JUPYTERHUB_HOST $KEYCLOAK_HOST/" /etc/hosts
           else
-            echo $(hostname -i) {jupyter,keycloak}.dev.k8tre.internal | sudo tee -a /etc/hosts
+            echo $(hostname -i) $JUPYTERHUB_HOST $KEYCLOAK_HOST | sudo tee -a /etc/hosts
           fi
           cat /etc/hosts
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - "dev-*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,9 +53,9 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pytest -v --color=yes
+          python -m pytest -v -s --color=yes
 
-      - name: Get logs, including on failure
+      - name: Get ArgoCD logs, including on failure
         if: always()
         run: |
           echo "::group::argocd-server"
@@ -69,6 +69,22 @@ jobs:
             echo "::group::argocd $kind"
             kubectl describe $kind -A
             echo "::endgroup::"
+          done
+
+      - name: Get main K8s resources, including on failure
+        if: always()
+        run: |
+          # Ignore errors since this is for debugging
+          set +e
+          for namespace in $(kubectl get namespace -ojsonpath='{.items[*].metadata.name}'); do
+            echo "***** $namespace *****"
+            for kind in daemonset deployment statefulset ingress service pod; do
+              for name in $(kubectl -n$namespace get $kind -ojsonpath='{.items[*].metadata.name}'); do
+                echo "::group::$kind/$name"
+                kubectl -n$namespace describe $kind/$name
+                echo "::endgroup::"
+              done
+            done
           done
 
   # Set a single status check for the whole workflow, so that we can use it in a

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,12 @@ jobs:
       KEYCLOAK_HOST: keycloak.k8tre.internal
 
     steps:
+
+      - name: Free up disk space on GitHub runner
+        uses: manics/action-free-disk-space@1.0.0
+        with:
+          desired-space: 40000
+
       - uses: actions/checkout@v4
 
       - name: Install uv

--- a/apps/jupyterhub/base/network_policy.yaml
+++ b/apps/jupyterhub/base/network_policy.yaml
@@ -45,7 +45,7 @@ spec:
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: allow-access-hub-to-keycloak
+  name: allow-access-hub-to-services
   namespace: jupyterhub
 spec:
   egress:
@@ -60,7 +60,38 @@ spec:
             # This is the pod not the service port
             - port: "8080"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: jupyterhub
+            app.kubernetes.io/instance: guacamolehandler
+            app.kubernetes.io/name: guacamolehandler
+      toPorts:
+        - ports:
+            - port: "8040"
+              protocol: TCP
   endpointSelector:
     matchLabels:
       app: jupyterhub
       component: hub
+
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-access-proxy-to-services
+  namespace: jupyterhub
+spec:
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: jupyterhub
+            app.kubernetes.io/instance: guacamolehandler
+            app.kubernetes.io/name: guacamolehandler
+      toPorts:
+        - ports:
+            - port: "8040"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app: jupyterhub
+      component: proxy

--- a/apps/jupyterhub/envs/dev/certificate-guacamole.yaml
+++ b/apps/jupyterhub/envs/dev/certificate-guacamole.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: guacamole-k8tre-tls
+  namespace: jupyterhub
+spec:
+  secretName: guacamole-k8tre-tls
+  privateKey:
+    rotationPolicy: Always
+  commonName: guacamole.dev.k8tre.internal
+  dnsNames:
+    - guacamole.dev.k8tre.internal
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer

--- a/apps/jupyterhub/envs/dev/guacamole-json-secret.yaml
+++ b/apps/jupyterhub/envs/dev/guacamole-json-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: guacamole-json-secret
+  namespace: jupyterhub
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: secret-store # name of the ClusterSecretStore to fetch the secrets from
+  target:
+    name: guacamole-json-secret # name of the k8s Secret to be created
+  data:
+    - secretKey: GUACAMOLE_JSON_SECRET_KEY
+      remoteRef:
+        key: guacamole-json-secret
+        property: GUACAMOLE_JSON_SECRET_KEY

--- a/apps/jupyterhub/envs/dev/guacamole.yaml
+++ b/apps/jupyterhub/envs/dev/guacamole.yaml
@@ -1,0 +1,31 @@
+guacamole:
+  env:
+    - name: JSON_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: guacamole-json-secret
+          key: GUACAMOLE_JSON_SECRET_KEY
+
+# guacd:
+#   podLabels:
+#     # Allow access to Z2JH singleuser pods
+#     hub.jupyter.org/network-access-singleuser: "true"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
+    # Default is 1m
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    # Increase for websockets (default is 60s)
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+  hosts:
+    - host: guacamole.dev.k8tre.internal
+      pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - guacamole.dev.k8tre.internal
+      secretName: guacamole-k8tre-tls
+

--- a/apps/jupyterhub/envs/dev/guacamolehandler.yaml
+++ b/apps/jupyterhub/envs/dev/guacamolehandler.yaml
@@ -1,0 +1,50 @@
+image:
+  repository: ghcr.io/manics/jupyterhub-guacamole-handler
+  tag: main
+  # tag: dev
+  # repository: docker.io/manics/jupyterhub-guacamole-handler
+  pullPolicy: Always
+
+command:
+  - python
+  - /opt/guacamole_handler/guacamole_handler.py
+
+args:
+  - --log-level=debug
+
+service:
+  port: 8040
+
+envDict:
+  GUACAMOLE_HOST: "http://guacamole:8080"
+  GUACAMOLE_PUBLIC_HOST: "https://guacamole.dev.k8tre.internal"
+  JUPYTERHUB_API_URL: http://hub:8081/hub/api
+  JUPYTERHUB_BASE_URL: /
+  JUPYTERHUB_CLIENT_ID: service-guacamole
+  JUPYTERHUB_SERVICE_PREFIX: /services/guacamole
+  # JUPYTERHUB_SERVICE_NAME: guacamole
+
+env:
+  # Secrets
+  - name: JSON_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: guacamole-json-secret
+        key: GUACAMOLE_JSON_SECRET_KEY
+  - name: JUPYTERHUB_API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: jupyterhub-secret
+        key: hub.services.guacamole.apiToken
+
+nameOverride: guacamolehandler
+
+livenessProbe:
+  httpGet:
+    path: /health
+readinessProbe:
+  httpGet:
+    path: /health
+
+podLabels:
+  hub.jupyter.org/network-access-hub: "true"

--- a/apps/jupyterhub/envs/dev/guacamolehandler.yaml
+++ b/apps/jupyterhub/envs/dev/guacamolehandler.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/manics/jupyterhub-guacamole-handler
-  tag: main
+  tag: 0.1.0
   # tag: dev
   # repository: docker.io/manics/jupyterhub-guacamole-handler
   pullPolicy: Always
@@ -23,6 +23,8 @@ envDict:
   JUPYTERHUB_CLIENT_ID: service-guacamole
   JUPYTERHUB_SERVICE_PREFIX: /services/guacamole
   # JUPYTERHUB_SERVICE_NAME: guacamole
+  # Disable clipboard copy, allow paste
+  DISABLE_CLIPBOARD: copy
 
 env:
   # Secrets

--- a/apps/jupyterhub/envs/dev/jupyterhub-secret.yaml
+++ b/apps/jupyterhub/envs/dev/jupyterhub-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jupyterhub-secret
+  namespace: jupyterhub
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: secret-store # name of the ClusterSecretStore to fetch the secrets from
+  target:
+    name: jupyterhub-secret # name of the k8s Secret to be created
+  data:
+    - secretKey: hub.services.guacamole.apiToken
+      remoteRef:
+        key: jupyterhub-secret
+        property: hub.services.guacamole.apiToken

--- a/apps/jupyterhub/envs/dev/jupyterhub_extraconfig.py
+++ b/apps/jupyterhub/envs/dev/jupyterhub_extraconfig.py
@@ -1,0 +1,245 @@
+import re
+
+from kubernetes_asyncio.client.models import V1EnvVar, V1ServicePort
+from kubespawner import KubeSpawner
+from tornado.web import HTTPError
+from traitlets import List, Unicode
+from secrets import token_urlsafe
+
+
+def modify_pod_hook(spawner, pod):
+    desktop_connection = spawner.desktop_connection
+    desktop_image = spawner.desktop_image
+    # desktop_username = spawner.desktop_username
+    desktop_command = spawner.desktop_command
+
+    if spawner.desktop_password is not None:
+        desktop_password = spawner.desktop_password
+    else:
+        spawner.desktop_password = desktop_password = token_urlsafe(24)
+
+    # First container is static-redirector, move user volume to user container
+    pod.spec.containers[1].volume_mounts = pod.spec.containers[0].volume_mounts
+    pod.spec.containers[0].volume_mounts = None
+
+    # Move lifecycle hook to user container
+    pod.spec.containers[1].lifecycle = pod.spec.containers[0].lifecycle
+    pod.spec.containers[0].lifecycle = None
+
+    # Desktop image
+    pod.spec.containers[1].image = desktop_image
+
+    # Set NEW_PASSWORD to override password if supported by image
+    env_var = V1EnvVar(name="NEW_PASSWORD", value=desktop_password)
+    if pod.spec.containers[1].env is None:
+        pod.spec.containers[1].env = []
+    pod.spec.containers[1].env.append(env_var)
+
+    # chosen_profile = spawner.user_options.get("profile", "")
+    pod.spec.containers[1].command = desktop_command
+
+    if desktop_connection not in {"rdp", "vnc"}:
+        raise ValueError(f"Invalid desktop_connection: {desktop_connection}")
+    # spawner.log.info(f"{chosen_profile=} {pod.spec.containers[1].command=}")
+    return pod
+
+
+def _safe_dump(d):
+    s = {}
+    for k, v in d.items():
+        if "password" in k:
+            s[k] = "********"
+        else:
+            s[k] = v
+    return s
+
+
+# TODO: This should be moved into an independent repo and tested thoroughly since
+# this touches some fairly low-level KubeSpawner areas
+class KubeSpawnerGuac(KubeSpawner):
+    desktop_connection = Unicode("Set by kubespawner_override")
+    desktop_image = Unicode("Set by kubespawner_override")
+    desktop_username = Unicode("Set by kubespawner_override")
+    desktop_password = Unicode(None, allow_none=True)
+    desktop_command = List(Unicode())
+
+    def load_state(self, state):
+        super().load_state(state)
+        self.log.info(f"state={_safe_dump(state)}")
+
+        for desktop_attr in (
+            "desktop_connection",
+            "desktop_image",
+            "desktop_username",
+            "desktop_password",
+            "desktop_command",
+        ):
+            state_attr = state.get(desktop_attr)
+        if state_attr:
+            current_attr = getattr(self, desktop_attr)
+            if current_attr and current_attr != state_attr:
+                sanitised_attr = (
+                    "********" if "password" in desktop_attr else state_attr
+                )
+                self.log.error(
+                    f"Mismatch: {desktop_attr}={current_attr} state.{desktop_attr}={sanitised_attr}, not updating"
+                )
+            else:
+                setattr(self, desktop_attr, state_attr)
+
+    def get_state(self):
+        state = super().get_state()
+        for desktop_attr in (
+            "desktop_connection",
+            "desktop_image",
+            "desktop_username",
+            "desktop_password",
+            "desktop_command",
+        ):
+            current_attr = getattr(self, desktop_attr)
+            if current_attr:
+                state[desktop_attr] = current_attr
+        self.log.info(f"state={_safe_dump(state)}")
+        return state
+
+    def get_service_manifest(self, owner_reference):
+        service = super().get_service_manifest(owner_reference)
+        service.spec.ports.append(
+            V1ServicePort(name="rdp", port=3389, target_port=3389)
+        )
+        service.spec.ports.append(
+            V1ServicePort(name="vnc", port=5901, target_port=5901)
+        )
+        return service
+
+
+# TODO: We should make require TRE projects to have a prefix to disinguish them from JupyterHub roles
+# project_group_re = r"^project-[a-z0-9-]+$"
+project_group_re = r"^.+$"
+# egress_admin_groupname = "egress-admins"
+# user_home_pvcname = "user-home-directories"
+# user_egress_pvcname = "user-egress-directories"
+# project_pvcname = "project-directories"
+# egress_pvcname = "airlock-egress-directories"
+
+
+# https://discourse.jupyter.org/t/tailoring-spawn-options-and-server-configuration-to-certain-users/8449
+async def custom_options_form(spawner):
+    spawner.profile_list = []
+    username = spawner.user.name
+
+    for group in spawner.user.groups:
+        groupname = group.name
+        if re.match(project_group_re, groupname):
+            spawner.log.info(f"Adding {groupname} project storage for {username}.")
+            pvc_name = f"project-{groupname}"
+            common_overrides = {
+                # Use the project as a shared volume for all users in project
+                "pvc_name_template": pvc_name,
+                # pvc_name_template is exapnded in the wrong place
+                # https://github.com/jupyterhub/kubespawner/issues/761
+                "pvc_name": pvc_name,
+                "volumes": {
+                    "home": {
+                        "name": "home",
+                        "persistentVolumeClaim": {
+                            "claimName": pvc_name,
+                        },
+                    },
+                },
+                "volume_mounts": {
+                    "home": {
+                        "name": "home",
+                        "mountPath": "/home/ubuntu",
+                        "subPath": f"{username}",
+                    },
+                },
+            }
+
+            spawner.profile_list.append(
+                {
+                    "display_name": f"{groupname}-mate",
+                    "slug": f"{groupname}-mate",
+                    "kubespawner_override": {
+                        **common_overrides,
+                        "desktop_connection": "rdp",
+                        "desktop_image": "ghcr.io/manics/ubuntu-mate-vncrdp:main",
+                        # "desktop_image": "ghcr.io/manics/ubuntu-mate-vncrdp:dev",
+                        "desktop_username": "ubuntu",
+                        "desktop_command": ["start-xrdp.sh"],
+                    },
+                }
+            )
+            spawner.profile_list.append(
+                {
+                    "display_name": f"{groupname}-mate (VNC)",
+                    "slug": f"{groupname}-mate-vnc",
+                    "kubespawner_override": {
+                        **common_overrides,
+                        "desktop_connection": "vnc",
+                        "desktop_image": "ghcr.io/manics/ubuntu-mate-vncrdp:main",
+                        "desktop_username": "ubuntu",
+                        "desktop_command": ["start-tigervnc.sh"],
+                    },
+                }
+            )
+            # spawner.profile_list.append(
+            #     {
+            #         "display_name": f"{groupname}-winxp",
+            #         "slug": f"{groupname}-winxp",
+            #         "kubespawner_override": {
+            #             **common_overrides,
+            #             "desktop_connection": "vnc",
+            #             "desktop_image": "ghcr.io/manics/jupyter-desktop-winxp:latest",
+            #             "desktop_username": "ubuntu",
+            #             "desktop_command": ["start-tigervnc.sh"],
+            #         },
+            #     }
+            # )
+
+    #         if groupname == egress_admin_groupname:
+    #             spawner.log.info(f"Adding {groupname} readonly storage for {username}.")
+    #             spawner.profile_list.append(
+    #                 {
+    #                     "display_name": groupname,
+    #                     "slug": groupname,
+    #                     "kubespawner_override": {
+    #                         "desktop_connection": desktop_connection,
+    #                         "volumes": {
+    #                             "home": {
+    #                                 "name": "home",
+    #                                 "persistentVolumeClaim": {
+    #                                     "claimName": user_home_pvcname,
+    #                                 },
+    #                             },
+    #                             "egress-review": {
+    #                                 "name": "egress-review",
+    #                                 "persistentVolumeClaim": {
+    #                                     "claimName": egress_pvcname,
+    #                                 },
+    #                             },
+    #                         },
+    #                         "volume_mounts": {
+    #                             "home": {
+    #                                 "name": "home",
+    #                                 "mountPath": f"/home/ubuntu",
+    #                                 "subPath": f"{groupname}/{username}",
+    #                             },
+    #                             "egress-review": {
+    #                                 "name": "egress-review",
+    #                                 "mountPath": f"/home/ubuntu/egress-review",
+    #                                 "readOnly": True,
+    #                             },
+    #                         },
+    #                     },
+    #                 }
+    #             )
+
+    if not spawner.profile_list:
+        raise HTTPError(500, "No profiles found")
+    return spawner._options_form_default()
+
+
+c.KubeSpawner.modify_pod_hook = modify_pod_hook  # noqa: F821
+c.JupyterHub.spawner_class = KubeSpawnerGuac  # noqa: F821
+c.KubeSpawner.options_form = custom_options_form  # noqa: F821

--- a/apps/jupyterhub/envs/dev/kustomization.yaml
+++ b/apps/jupyterhub/envs/dev/kustomization.yaml
@@ -8,9 +8,27 @@ helmCharts:
     releaseName: jupyterhub
     namespace: jupyterhub
     valuesFile: values.yaml
-      
+
+  - name: guacamole
+    repo: https://www.manicstreetpreacher.co.uk/helm-guacamole/
+    version: 0.1.2
+    releaseName: guacamole
+    namespace: jupyterhub
+    valuesFile: guacamole.yaml
+
+  - name: generic-webservice
+    repo: https://www.manicstreetpreacher.co.uk/helm-generic-webservice/
+    version: 0.1.5
+    releaseName: guacamolehandler
+    namespace: jupyterhub
+    valuesFile: guacamolehandler.yaml
+
 resources:
   - ../../base
+  - certificate-guacamole.yaml
+  - guacamole-json-secret.yaml
+  - jupyterhub-secret.yaml
+  - netpol-singleuser.yaml
   # - netpol_singleuser_world.yaml
 
 patches:
@@ -18,3 +36,9 @@ patches:
     target:
       kind: Certificate
       name: jupyter-k8tre-tls
+
+configMapGenerator:
+  - name: jupyterhub-extraconfig
+    files:
+      # Kustomize will create a ConfigMap with the contents of this file
+      - jupyterhub_extraconfig.py

--- a/apps/jupyterhub/envs/dev/netpol-singleuser.yaml
+++ b/apps/jupyterhub/envs/dev/netpol-singleuser.yaml
@@ -1,0 +1,27 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-access-singleuser-services
+  namespace: jupyterhub
+spec:
+  description: Allow Guacamole to access singleuser-server
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: singleuser-server
+      app.kubernetes.io/instance: jupyterhub
+      app.kubernetes.io/managed-by: kubespawner
+      app.kubernetes.io/name: jupyterhub
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: jupyterhub
+            app.kubernetes.io/component: guacd
+            app.kubernetes.io/instance: guacamole
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: guacamole
+      toPorts:
+        - ports:
+            - port: "3389"
+              protocol: TCP
+            - port: "5901"
+              protocol: TCP

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -43,6 +43,8 @@ hub:
       validate_server_cert: false
     JupyterHub:
       authenticator_class: generic-oauth
+      # Makes testing easier
+      default_url: /hub/home
 proxy:
   service:
     type: ClusterIP

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -45,9 +45,61 @@ hub:
       authenticator_class: generic-oauth
       # Makes testing easier
       default_url: /hub/home
+    KubeSpawner:
+      # Allow routing by hostname
+      services_enabled: true
+
+  # extraEnv:
+
+  # Can't use helm --set-file, so pass in as a configMap using extraVolumes
+  # extraConfig:
+  #   10-notatre:
+  extraVolumeMounts:
+    - name: jupyterhub-extraconfig
+      mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_extraconfig.py
+      subPath: jupyterhub_extraconfig.py
+  extraVolumes:
+    - name: jupyterhub-extraconfig
+      configMap:
+        name: jupyterhub-extraconfig
+        items:
+          - key: jupyterhub_extraconfig.py
+            path: jupyterhub_extraconfig.py
+
+  existingSecret: jupyterhub-secret
+
+  services:
+    guacamole:
+      url: http://guacamolehandler:8040
+      # this allows us to get the user's username
+      oauth_client_allowed_scopes:
+        - "read:users!user"
+      # We subsequently need to use the services own API token to get privileged
+      # information about the server (see loadRoles)
+      # api_token: jupyterhub-secret
+      oauth_no_confirm: true
+
+  loadRoles:
+    # grant all users access to all services
+    user:
+      scopes:
+        - "access:services"
+        - "self"
+    # Allow the guacamole-handler service to access detailed server info
+    guacamole-handler:
+      scopes:
+        - "read:servers"
+        - "admin:server_state"
+      services:
+        - guacamole
+
+
+
+
 proxy:
   service:
     type: ClusterIP
+
 singleuser:
   cloudMetadata:
     # This requires elevated permissions which should be avoided. Use network policies instead.
@@ -55,6 +107,73 @@ singleuser:
     blockWithIptables: false
   networkPolicy:
     enabled: false # These are managed by Cilium network policies
+
+  # storage:
+  #   # Everything is done dynamically in the profile handling
+  #   type: none
+
+  image:
+    # name: ghcr.io/manics/jupyter-desktop-winxp
+    # tag: latest
+    name: ghcr.io/manics/jupyterhub-singleuser-static-redirector
+    tag: main
+    pullPolicy: Always
+  # Use default entrypoint
+  cmd:
+  extraEnv:
+    STATIC_REDIRECTOR_DESTINATION: https://jupyter.dev.k8tre.internal/services/guacamole/
+    STATIC_REDIRECTOR_AUTOREDIRECT: "true"
+  extraContainers:
+    - name: ubuntu-mate
+      # Set by kubespawner_override, but this will automatically pull it
+      image: "ghcr.io/manics/ubuntu-mate-vncrdp:main"
+      command:
+        # Set by modify_pod_hook
+        - "false"
+      ports:
+        - containerPort: 3389
+          name: rdp
+          protocol: TCP
+        - containerPort: 5901
+          name: vnc
+          protocol: TCP
+      env: []
+
+  # startTimeout: 300
+  # Use the default UID from the image
+  uid:
+  # networkPolicy:
+    # Uncomment the following to use internal coredns-restricted
+    # egressAllowRules:
+    #   dnsPortsCloudMetadataServer: false
+    #   dnsPortsKubeSystemNamespace: false
+    #   dnsPortsPrivateIPs: false
+    #   nonPrivateIPs: false
+    #   privateIPs: false
+    # egress:
+    #   - to:
+    #       - podSelector:
+    #           matchLabels:
+    #             user-pod-dns: "true"
+    #             app.kubernetes.io/instance: coredns-restricted
+    #             app.kubernetes.io/name: coredns
+    #     ports:
+    #       - protocol: UDP
+    #         port: 53
+
+    # Allow ingress from guacd
+    # ingress:
+    #   - from:
+    #       - podSelector:
+    #           matchLabels:
+    #             app.kubernetes.io/component: guacd
+    #             app.kubernetes.io/name: guacamole
+    #   - ports:
+    #       - port: 3389
+    #         protocol: TCP
+    #       - port: 5901
+    #         protocol: TCP
+
 ingress:
   enabled: true
   hosts:
@@ -68,3 +187,5 @@ ingress:
         - jupyter.dev.k8tre.internal
       secretName: jupyter-k8tre-tls
 
+debug:
+  enabled: true

--- a/apps/keycloak/base/keycloak-admin-secret.yaml
+++ b/apps/keycloak/base/keycloak-admin-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-admin-secret
+  namespace: keycloak
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: secret-store
+  target:
+    name: keycloak-admin-secret
+  data:
+    - secretKey: admin-password
+      remoteRef:
+        key: keycloak-admin-secret
+        property: admin-password

--- a/apps/keycloak/base/kustomization.yaml
+++ b/apps/keycloak/base/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: keycloak
 # See https://www.keycloak.org/operator/installation#_installing_multiple_operators
 resources:
   - certificate.yaml
+  - keycloak-admin-secret.yaml
   - keycloak-db-external-secret.yaml

--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -19,3 +19,6 @@ ingress:
     - secretName: keycloak-k8tre-tls
       hosts:
         - keycloak.dev.k8tre.internal
+
+logging:
+  level: DEBUG

--- a/apps/keycloak/envs/dev/values.yaml
+++ b/apps/keycloak/envs/dev/values.yaml
@@ -19,6 +19,10 @@ ingress:
     - secretName: keycloak-k8tre-tls
       hosts:
         - keycloak.dev.k8tre.internal
+auth:
+  adminUser: admin
+  existingSecret: keycloak-admin-secret
+  passwordSecretKey: admin-password
 
 logging:
   level: DEBUG

--- a/ci/ci-secrets.yaml
+++ b/ci/ci-secrets.yaml
@@ -17,5 +17,12 @@ secrets:
       - key: database
         value: "keycloak"
 
+  # Keycloak admin password
+  - name: keycloak-admin-secret
+    type: generic
+    data:
+      - key: admin-password
+        value: "{{ generate_password }}"
+
   # TLS secrets are now managed by cert-manager
   # Remove TLS secret configurations and use cert-manager resources instead

--- a/ci/ci-secrets.yaml
+++ b/ci/ci-secrets.yaml
@@ -26,3 +26,18 @@ secrets:
 
   # TLS secrets are now managed by cert-manager
   # Remove TLS secret configurations and use cert-manager resources instead
+
+  # Guacamole internal JSON auth token
+  - name: guacamole-json-secret
+    type: generic
+    data:
+      - key: GUACAMOLE_JSON_SECRET_KEY
+        value: "{{ generate_hex_key 16 }}"
+
+  # JupyterHub shared secrets
+  - name: jupyterhub-secret
+    type: generic
+    data:
+      # Guacamole handler API token token
+      - key: hub.services.guacamole.apiToken
+        value: "{{ generate_hex_key }}"

--- a/ci/ci-setup-keycloak.py
+++ b/ci/ci-setup-keycloak.py
@@ -3,59 +3,9 @@
 # https://github.com/marcospereirampj/python-keycloak
 from argparse import ArgumentParser
 import json
-from keycloak import KeycloakAdmin
+from keycloak import KeycloakAdmin, exceptions
 import sys
-
-parser = ArgumentParser()
-parser.add_argument(
-    "--keycloak-url", default="https://keycloak.dev.k8tre.internal", help="Keycloak URL"
-)
-parser.add_argument(
-    "--jupyterhub-url",
-    default="https://jupyter.dev.k8tre.internal",
-    help="JupyterHub URL",
-)
-parser.add_argument("--keycloak-admin", default="admin", help="Keycloak admin user")
-parser.add_argument(
-    "--keycloak-password", default="admin", help="Keycloak admin password"
-)
-parser.add_argument(
-    "--user", default="example@example.com", help="Username of new user"
-)
-parser.add_argument("--password", default="secret", help="Password for new user")
-parser.add_argument("--firstname", default="Example", help="First name of new user")
-parser.add_argument("--lastname", default="User", help="Last name of new user")
-parser.add_argument(
-    "--client-name", default="jupyterhub", help="JupyterHub OAuth client name"
-)
-parser.add_argument(
-    "--client-secret",
-    default="jupyterhub-client-secret",
-    help="JupyterHub OAuth client secret",
-)
-parser.add_argument(
-    "--admin-role",
-    default="k8tre-admins",
-    help="Name of K8TRE Keycloak admin role",
-)
-parser.add_argument(
-    "--user-role",
-    default="k8tre-users",
-    help="Name of K8TRE Keycloak user role",
-)
-parser.add_argument(
-    "--scope-name",
-    default="k8tre-roles",
-    help="Custom scope name to use for K8TRE Keycloak roles",
-)
-parser.add_argument(
-    "--verify",
-    default="true",
-    help="Set to the path to a CA, or 'false' to disable SSL verification, default is to use system CA",
-)
-
-
-args = parser.parse_args()
+from time import sleep
 
 
 def output(firstline, message=None):
@@ -68,137 +18,206 @@ def output(firstline, message=None):
         print(json.dumps(message, indent=2))
 
 
-jupyterhub_url = args.jupyterhub_url
+def run(args):
+    verify = args.verify
+    if verify.lower() == "true":
+        verify = True
+    elif verify.lower() == "false":
+        verify = False
 
-verify = args.verify
-if verify.lower() == "true":
-    verify = True
-elif verify.lower() == "false":
-    verify = False
+    keycloak_admin = KeycloakAdmin(
+        server_url=args.keycloak_url,
+        username=args.keycloak_admin,
+        password=args.keycloak_password,
+        realm_name="master",
+        verify=verify,
+    )
 
-keycloak_admin = KeycloakAdmin(
-    server_url=args.keycloak_url,
-    username=args.keycloak_admin,
-    password=args.keycloak_password,
-    realm_name="master",
-    verify=verify,
-)
+    # Create a user
+    user_payload = {
+        "email": args.user,
+        "username": args.user,
+        "enabled": True,
+        "firstName": args.firstname,
+        "lastName": args.lastname,
+        "credentials": [
+            {
+                "value": args.password,
+                "type": "password",
+            }
+        ],
+    }
+    uid = keycloak_admin.get_user_id(args.user)
+    if uid:
+        output(f"Updating user {args.user} ({uid})", user_payload)
+        keycloak_admin.update_user(uid, user_payload)
+    else:
+        output(f"Creating user {args.user}", user_payload)
+        keycloak_admin.create_user(user_payload)
 
-# Create a user
-user_payload = {
-    "email": args.user,
-    "username": args.user,
-    "enabled": True,
-    "firstName": args.firstname,
-    "lastName": args.lastname,
-    "credentials": [
-        {
-            "value": args.password,
-            "type": "password",
-        }
-    ],
-}
-uid = keycloak_admin.get_user_id(args.user)
-if uid:
-    output(f"Updating user {args.user} ({uid})", user_payload)
-    keycloak_admin.update_user(uid, user_payload)
-else:
-    output(f"Creating user {args.user}", user_payload)
-    keycloak_admin.create_user(user_payload)
+    # Create an OAuth client for JupyterHub
+    client_payload = {
+        "clientId": args.client_name,
+        "name": args.client_name,
+        "rootUrl": args.jupyterhub_url.rstrip("/"),
+        "baseUrl": "/",
+        "redirectUris": ["/hub/oauth_callback"],
+        "clientAuthenticatorType": "client-secret",
+        "secret": args.client_secret,
+    }
+    cid = keycloak_admin.get_client_id(args.client_name)
+    if cid:
+        output(f"Updating client {args.client_name} ({cid})", client_payload)
+        keycloak_admin.update_client(cid, client_payload)
+    else:
+        output(f"Creating client {args.client_name}", client_payload)
+        cid = keycloak_admin.create_client(client_payload)
+    # print(keycloak_admin.get_client(cid))
 
-# Create an OAuth client for JupyterHub
-client_payload = {
-    "clientId": args.client_name,
-    "name": args.client_name,
-    "rootUrl": args.jupyterhub_url.rstrip("/"),
-    "baseUrl": "/",
-    "redirectUris": ["/hub/oauth_callback"],
-    "clientAuthenticatorType": "client-secret",
-    "secret": args.client_secret,
-}
-cid = keycloak_admin.get_client_id(args.client_name)
-if cid:
-    output(f"Updating client {args.client_name} ({cid})", client_payload)
-    keycloak_admin.update_client(cid, client_payload)
-else:
-    output(f"Creating client {args.client_name}", client_payload)
-    cid = keycloak_admin.create_client(client_payload)
-# print(keycloak_admin.get_client(cid))
+    # Create some roles that can be used by multiple clients
+    role_admins_payload = {
+        "name": args.admin_role,
+        "description": "K8TRE admins",
+    }
+    # output(f"Creating/updating client role {args.admin_role}", role_admins_payload)
+    # keycloak_admin.create_client_role(cid, role_admins_payload, skip_exists=True)
+    output(f"Creating/updating realm role {args.admin_role}", role_admins_payload)
+    keycloak_admin.create_realm_role(role_admins_payload, skip_exists=True)
 
-# Create some roles that can be used by multiple clients
-role_admins_payload = {
-    "name": args.admin_role,
-    "description": "K8TRE admins",
-}
-# output(f"Creating/updating client role {args.admin_role}", role_admins_payload)
-# keycloak_admin.create_client_role(cid, role_admins_payload, skip_exists=True)
-output(f"Creating/updating realm role {args.admin_role}", role_admins_payload)
-keycloak_admin.create_realm_role(role_admins_payload, skip_exists=True)
+    role_users_payload = {
+        "name": args.user_role,
+        "description": "K8TRE users",
+    }
+    # output(f"Creating/updating client role {args.user_role}", role_users_payload)
+    # keycloak_admin.create_client_role(cid, role_users_payload, skip_exists=True)
+    output(f"Creating/updating realm role {args.user_role}", role_users_payload)
+    keycloak_admin.create_realm_role(role_users_payload, skip_exists=True)
 
-role_users_payload = {
-    "name": args.user_role,
-    "description": "K8TRE users",
-}
-# output(f"Creating/updating client role {args.user_role}", role_users_payload)
-# keycloak_admin.create_client_role(cid, role_users_payload, skip_exists=True)
-output(f"Creating/updating realm role {args.user_role}", role_users_payload)
-keycloak_admin.create_realm_role(role_users_payload, skip_exists=True)
+    # Create or update a custom scope called "k8tre-groups" that maps Keycloak Roles
+    scope = {
+        "name": args.scope_name,
+        "description": "K8TRE Keycloak roles",
+        "protocol": "openid-connect",
+        "protocolMappers": [
+            {
+                "name": args.scope_name,
+                "protocol": "openid-connect",
+                # # Map client roles:
+                # "protocolMapper": "oidc-usermodel-client-role-mapper",
+                # Map realm roles:
+                "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                # # Map Keycloak groups:
+                # "protocolMapper": "oidc-group-membership-mapper",
+                "config": {
+                    "multivalued": "true",
+                    # Include in the userinfo response
+                    "userinfo.token.claim": "true",
+                    # The userinfo field
+                    "claim.name": "k8tre.roles",
+                    "jsonType.label": "String",
+                    # # Only return client scopes for jupyterhub
+                    # "usermodel.clientRoleMapping.clientId": args.client_name,
+                },
+            }
+        ],
+    }
+    output(f"Creating or updating scope {args.scope_name}", scope)
+    scope_id = keycloak_admin.create_client_scope(scope, skip_exists=True)
+    keycloak_admin.update_client_scope(scope_id, scope)
 
-# Create or update a custom scope called "k8tre-groups" that maps Keycloak Roles
-scope = {
-    "name": args.scope_name,
-    "description": "K8TRE Keycloak roles",
-    "protocol": "openid-connect",
-    "protocolMappers": [
-        {
-            "name": args.scope_name,
-            "protocol": "openid-connect",
+    # Add scope to client
+    keycloak_admin.add_client_optional_client_scope(cid, scope_id, {})
 
-            # # Map client roles:
-            # "protocolMapper": "oidc-usermodel-client-role-mapper",
+    # Assign users to roles
+    # admin_role = keycloak_admin.get_client_role(cid, args.admin_role)
+    # user_role = keycloak_admin.get_client_role(cid, args.user_role)
+    admin_role = keycloak_admin.get_realm_role(args.admin_role)
+    user_role = keycloak_admin.get_realm_role(args.user_role)
 
-            # Map realm roles:
-            "protocolMapper": "oidc-usermodel-realm-role-mapper",
+    admin_uid = keycloak_admin.get_user_id(args.keycloak_admin)
+    output(
+        f"Assigning roles to admin {args.keycloak_admin} ({admin_uid})",
+        [admin_role, user_role],
+    )
+    # keycloak_admin.assign_client_role(admin_uid, cid, [admin_role, user_role])
+    keycloak_admin.assign_realm_roles(admin_uid, [admin_role, user_role])
 
-            # # Map Keycloak groups:
-            # "protocolMapper": "oidc-group-membership-mapper",
+    user_uid = keycloak_admin.get_user_id(args.user)
+    output(f"Assigning roles to user {args.user} ({user_uid})", user_role)
+    # keycloak_admin.assign_client_role(user_uid, cid, [user_role])
+    keycloak_admin.assign_realm_roles(user_uid, [user_role])
 
-            "config": {
-                "multivalued": "true",
-                # Include in the userinfo response
-                "userinfo.token.claim": "true",
-                # The userinfo field
-                "claim.name": "k8tre.roles",
-                "jsonType.label": "String",
 
-                # # Only return client scopes for jupyterhub
-                # "usermodel.clientRoleMapping.clientId": args.client_name,
-            },
-        }
-    ],
-}
-output(f"Creating or updating scope {args.scope_name}", scope)
-scope_id = keycloak_admin.create_client_scope(scope, skip_exists=True)
-keycloak_admin.update_client_scope(scope_id, scope)
+def main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--keycloak-url",
+        default="https://keycloak.dev.k8tre.internal",
+        help="Keycloak URL",
+    )
+    parser.add_argument(
+        "--jupyterhub-url",
+        default="https://jupyter.dev.k8tre.internal",
+        help="JupyterHub URL",
+    )
+    parser.add_argument("--keycloak-admin", default="admin", help="Keycloak admin user")
+    parser.add_argument(
+        "--keycloak-password", default="admin", help="Keycloak admin password"
+    )
+    parser.add_argument(
+        "--user", default="example@example.com", help="Username of new user"
+    )
+    parser.add_argument("--password", default="secret", help="Password for new user")
+    parser.add_argument("--firstname", default="Example", help="First name of new user")
+    parser.add_argument("--lastname", default="User", help="Last name of new user")
+    parser.add_argument(
+        "--client-name", default="jupyterhub", help="JupyterHub OAuth client name"
+    )
+    parser.add_argument(
+        "--client-secret",
+        default="jupyterhub-client-secret",
+        help="JupyterHub OAuth client secret",
+    )
+    parser.add_argument(
+        "--admin-role",
+        default="k8tre-admins",
+        help="Name of K8TRE Keycloak admin role",
+    )
+    parser.add_argument(
+        "--user-role",
+        default="k8tre-users",
+        help="Name of K8TRE Keycloak user role",
+    )
+    parser.add_argument(
+        "--scope-name",
+        default="k8tre-roles",
+        help="Custom scope name to use for K8TRE Keycloak roles",
+    )
+    parser.add_argument(
+        "--verify",
+        default="true",
+        help="Set to the path to a CA, or 'false' to disable SSL verification, default is to use system CA",
+    )
+    parser.add_argument(
+        "--retry",
+        default=1,
+        type=int,
+        help="Automatrically retry if there's a failure, use in CI",
+    )
 
-# Add scope to client
-keycloak_admin.add_client_optional_client_scope(cid, scope_id, {})
+    delay = 30
 
-# Assign users to roles
-# admin_role = keycloak_admin.get_client_role(cid, args.admin_role)
-# user_role = keycloak_admin.get_client_role(cid, args.user_role)
-admin_role = keycloak_admin.get_realm_role(args.admin_role)
-user_role = keycloak_admin.get_realm_role(args.user_role)
+    args = parser.parse_args()
+    for r in range(args.retry):
+        try:
+            run(args)
+        except exceptions.KeycloakError as e:
+            print(f"ERROR: {repr(e)}")
+            if r == args.retry - 1:
+                raise
+            print(f"Retrying after {delay} s")
+            sleep(delay)
 
-admin_uid = keycloak_admin.get_user_id(args.keycloak_admin)
-output(
-    f"Assigning roles to admin {args.keycloak_admin} ({admin_uid})",
-    [admin_role, user_role],
-)
-# keycloak_admin.assign_client_role(admin_uid, cid, [admin_role, user_role])
-keycloak_admin.assign_realm_roles(admin_uid, [admin_role, user_role])
 
-user_uid = keycloak_admin.get_user_id(args.user)
-output(f"Assigning roles to user {args.user} ({user_uid})", user_role)
-# keycloak_admin.assign_client_role(user_uid, cid, [user_role])
-keycloak_admin.assign_realm_roles(user_uid, [user_role])
+if __name__ == "__main__":
+    main()

--- a/ci/ci-setup-keycloak.py
+++ b/ci/ci-setup-keycloak.py
@@ -3,9 +3,59 @@
 # https://github.com/marcospereirampj/python-keycloak
 from argparse import ArgumentParser
 import json
-from keycloak import KeycloakAdmin, exceptions
+from keycloak import KeycloakAdmin
 import sys
-from time import sleep
+
+parser = ArgumentParser()
+parser.add_argument(
+    "--keycloak-url", default="https://keycloak.dev.k8tre.internal", help="Keycloak URL"
+)
+parser.add_argument(
+    "--jupyterhub-url",
+    default="https://jupyter.dev.k8tre.internal",
+    help="JupyterHub URL",
+)
+parser.add_argument("--keycloak-admin", default="admin", help="Keycloak admin user")
+parser.add_argument(
+    "--keycloak-password", default="admin", help="Keycloak admin password"
+)
+parser.add_argument(
+    "--user", default="example@example.com", help="Username of new user"
+)
+parser.add_argument("--password", default="secret", help="Password for new user")
+parser.add_argument("--firstname", default="Example", help="First name of new user")
+parser.add_argument("--lastname", default="User", help="Last name of new user")
+parser.add_argument(
+    "--client-name", default="jupyterhub", help="JupyterHub OAuth client name"
+)
+parser.add_argument(
+    "--client-secret",
+    default="jupyterhub-client-secret",
+    help="JupyterHub OAuth client secret",
+)
+parser.add_argument(
+    "--admin-role",
+    default="k8tre-admins",
+    help="Name of K8TRE Keycloak admin role",
+)
+parser.add_argument(
+    "--user-role",
+    default="k8tre-users",
+    help="Name of K8TRE Keycloak user role",
+)
+parser.add_argument(
+    "--scope-name",
+    default="k8tre-roles",
+    help="Custom scope name to use for K8TRE Keycloak roles",
+)
+parser.add_argument(
+    "--verify",
+    default="true",
+    help="Set to the path to a CA, or 'false' to disable SSL verification, default is to use system CA",
+)
+
+
+args = parser.parse_args()
 
 
 def output(firstline, message=None):
@@ -18,206 +68,137 @@ def output(firstline, message=None):
         print(json.dumps(message, indent=2))
 
 
-def run(args):
-    verify = args.verify
-    if verify.lower() == "true":
-        verify = True
-    elif verify.lower() == "false":
-        verify = False
+jupyterhub_url = args.jupyterhub_url
 
-    keycloak_admin = KeycloakAdmin(
-        server_url=args.keycloak_url,
-        username=args.keycloak_admin,
-        password=args.keycloak_password,
-        realm_name="master",
-        verify=verify,
-    )
+verify = args.verify
+if verify.lower() == "true":
+    verify = True
+elif verify.lower() == "false":
+    verify = False
 
-    # Create a user
-    user_payload = {
-        "email": args.user,
-        "username": args.user,
-        "enabled": True,
-        "firstName": args.firstname,
-        "lastName": args.lastname,
-        "credentials": [
-            {
-                "value": args.password,
-                "type": "password",
-            }
-        ],
-    }
-    uid = keycloak_admin.get_user_id(args.user)
-    if uid:
-        output(f"Updating user {args.user} ({uid})", user_payload)
-        keycloak_admin.update_user(uid, user_payload)
-    else:
-        output(f"Creating user {args.user}", user_payload)
-        keycloak_admin.create_user(user_payload)
+keycloak_admin = KeycloakAdmin(
+    server_url=args.keycloak_url,
+    username=args.keycloak_admin,
+    password=args.keycloak_password,
+    realm_name="master",
+    verify=verify,
+)
 
-    # Create an OAuth client for JupyterHub
-    client_payload = {
-        "clientId": args.client_name,
-        "name": args.client_name,
-        "rootUrl": args.jupyterhub_url.rstrip("/"),
-        "baseUrl": "/",
-        "redirectUris": ["/hub/oauth_callback"],
-        "clientAuthenticatorType": "client-secret",
-        "secret": args.client_secret,
-    }
-    cid = keycloak_admin.get_client_id(args.client_name)
-    if cid:
-        output(f"Updating client {args.client_name} ({cid})", client_payload)
-        keycloak_admin.update_client(cid, client_payload)
-    else:
-        output(f"Creating client {args.client_name}", client_payload)
-        cid = keycloak_admin.create_client(client_payload)
-    # print(keycloak_admin.get_client(cid))
+# Create a user
+user_payload = {
+    "email": args.user,
+    "username": args.user,
+    "enabled": True,
+    "firstName": args.firstname,
+    "lastName": args.lastname,
+    "credentials": [
+        {
+            "value": args.password,
+            "type": "password",
+        }
+    ],
+}
+uid = keycloak_admin.get_user_id(args.user)
+if uid:
+    output(f"Updating user {args.user} ({uid})", user_payload)
+    keycloak_admin.update_user(uid, user_payload)
+else:
+    output(f"Creating user {args.user}", user_payload)
+    keycloak_admin.create_user(user_payload)
 
-    # Create some roles that can be used by multiple clients
-    role_admins_payload = {
-        "name": args.admin_role,
-        "description": "K8TRE admins",
-    }
-    # output(f"Creating/updating client role {args.admin_role}", role_admins_payload)
-    # keycloak_admin.create_client_role(cid, role_admins_payload, skip_exists=True)
-    output(f"Creating/updating realm role {args.admin_role}", role_admins_payload)
-    keycloak_admin.create_realm_role(role_admins_payload, skip_exists=True)
+# Create an OAuth client for JupyterHub
+client_payload = {
+    "clientId": args.client_name,
+    "name": args.client_name,
+    "rootUrl": args.jupyterhub_url.rstrip("/"),
+    "baseUrl": "/",
+    "redirectUris": ["/hub/oauth_callback"],
+    "clientAuthenticatorType": "client-secret",
+    "secret": args.client_secret,
+}
+cid = keycloak_admin.get_client_id(args.client_name)
+if cid:
+    output(f"Updating client {args.client_name} ({cid})", client_payload)
+    keycloak_admin.update_client(cid, client_payload)
+else:
+    output(f"Creating client {args.client_name}", client_payload)
+    cid = keycloak_admin.create_client(client_payload)
+# print(keycloak_admin.get_client(cid))
 
-    role_users_payload = {
-        "name": args.user_role,
-        "description": "K8TRE users",
-    }
-    # output(f"Creating/updating client role {args.user_role}", role_users_payload)
-    # keycloak_admin.create_client_role(cid, role_users_payload, skip_exists=True)
-    output(f"Creating/updating realm role {args.user_role}", role_users_payload)
-    keycloak_admin.create_realm_role(role_users_payload, skip_exists=True)
+# Create some roles that can be used by multiple clients
+role_admins_payload = {
+    "name": args.admin_role,
+    "description": "K8TRE admins",
+}
+# output(f"Creating/updating client role {args.admin_role}", role_admins_payload)
+# keycloak_admin.create_client_role(cid, role_admins_payload, skip_exists=True)
+output(f"Creating/updating realm role {args.admin_role}", role_admins_payload)
+keycloak_admin.create_realm_role(role_admins_payload, skip_exists=True)
 
-    # Create or update a custom scope called "k8tre-groups" that maps Keycloak Roles
-    scope = {
-        "name": args.scope_name,
-        "description": "K8TRE Keycloak roles",
-        "protocol": "openid-connect",
-        "protocolMappers": [
-            {
-                "name": args.scope_name,
-                "protocol": "openid-connect",
-                # # Map client roles:
-                # "protocolMapper": "oidc-usermodel-client-role-mapper",
-                # Map realm roles:
-                "protocolMapper": "oidc-usermodel-realm-role-mapper",
-                # # Map Keycloak groups:
-                # "protocolMapper": "oidc-group-membership-mapper",
-                "config": {
-                    "multivalued": "true",
-                    # Include in the userinfo response
-                    "userinfo.token.claim": "true",
-                    # The userinfo field
-                    "claim.name": "k8tre.roles",
-                    "jsonType.label": "String",
-                    # # Only return client scopes for jupyterhub
-                    # "usermodel.clientRoleMapping.clientId": args.client_name,
-                },
-            }
-        ],
-    }
-    output(f"Creating or updating scope {args.scope_name}", scope)
-    scope_id = keycloak_admin.create_client_scope(scope, skip_exists=True)
-    keycloak_admin.update_client_scope(scope_id, scope)
+role_users_payload = {
+    "name": args.user_role,
+    "description": "K8TRE users",
+}
+# output(f"Creating/updating client role {args.user_role}", role_users_payload)
+# keycloak_admin.create_client_role(cid, role_users_payload, skip_exists=True)
+output(f"Creating/updating realm role {args.user_role}", role_users_payload)
+keycloak_admin.create_realm_role(role_users_payload, skip_exists=True)
 
-    # Add scope to client
-    keycloak_admin.add_client_optional_client_scope(cid, scope_id, {})
+# Create or update a custom scope called "k8tre-groups" that maps Keycloak Roles
+scope = {
+    "name": args.scope_name,
+    "description": "K8TRE Keycloak roles",
+    "protocol": "openid-connect",
+    "protocolMappers": [
+        {
+            "name": args.scope_name,
+            "protocol": "openid-connect",
 
-    # Assign users to roles
-    # admin_role = keycloak_admin.get_client_role(cid, args.admin_role)
-    # user_role = keycloak_admin.get_client_role(cid, args.user_role)
-    admin_role = keycloak_admin.get_realm_role(args.admin_role)
-    user_role = keycloak_admin.get_realm_role(args.user_role)
+            # # Map client roles:
+            # "protocolMapper": "oidc-usermodel-client-role-mapper",
 
-    admin_uid = keycloak_admin.get_user_id(args.keycloak_admin)
-    output(
-        f"Assigning roles to admin {args.keycloak_admin} ({admin_uid})",
-        [admin_role, user_role],
-    )
-    # keycloak_admin.assign_client_role(admin_uid, cid, [admin_role, user_role])
-    keycloak_admin.assign_realm_roles(admin_uid, [admin_role, user_role])
+            # Map realm roles:
+            "protocolMapper": "oidc-usermodel-realm-role-mapper",
 
-    user_uid = keycloak_admin.get_user_id(args.user)
-    output(f"Assigning roles to user {args.user} ({user_uid})", user_role)
-    # keycloak_admin.assign_client_role(user_uid, cid, [user_role])
-    keycloak_admin.assign_realm_roles(user_uid, [user_role])
+            # # Map Keycloak groups:
+            # "protocolMapper": "oidc-group-membership-mapper",
 
+            "config": {
+                "multivalued": "true",
+                # Include in the userinfo response
+                "userinfo.token.claim": "true",
+                # The userinfo field
+                "claim.name": "k8tre.roles",
+                "jsonType.label": "String",
 
-def main():
-    parser = ArgumentParser()
-    parser.add_argument(
-        "--keycloak-url",
-        default="https://keycloak.dev.k8tre.internal",
-        help="Keycloak URL",
-    )
-    parser.add_argument(
-        "--jupyterhub-url",
-        default="https://jupyter.dev.k8tre.internal",
-        help="JupyterHub URL",
-    )
-    parser.add_argument("--keycloak-admin", default="admin", help="Keycloak admin user")
-    parser.add_argument(
-        "--keycloak-password", default="admin", help="Keycloak admin password"
-    )
-    parser.add_argument(
-        "--user", default="example@example.com", help="Username of new user"
-    )
-    parser.add_argument("--password", default="secret", help="Password for new user")
-    parser.add_argument("--firstname", default="Example", help="First name of new user")
-    parser.add_argument("--lastname", default="User", help="Last name of new user")
-    parser.add_argument(
-        "--client-name", default="jupyterhub", help="JupyterHub OAuth client name"
-    )
-    parser.add_argument(
-        "--client-secret",
-        default="jupyterhub-client-secret",
-        help="JupyterHub OAuth client secret",
-    )
-    parser.add_argument(
-        "--admin-role",
-        default="k8tre-admins",
-        help="Name of K8TRE Keycloak admin role",
-    )
-    parser.add_argument(
-        "--user-role",
-        default="k8tre-users",
-        help="Name of K8TRE Keycloak user role",
-    )
-    parser.add_argument(
-        "--scope-name",
-        default="k8tre-roles",
-        help="Custom scope name to use for K8TRE Keycloak roles",
-    )
-    parser.add_argument(
-        "--verify",
-        default="true",
-        help="Set to the path to a CA, or 'false' to disable SSL verification, default is to use system CA",
-    )
-    parser.add_argument(
-        "--retry",
-        default=1,
-        type=int,
-        help="Automatrically retry if there's a failure, use in CI",
-    )
+                # # Only return client scopes for jupyterhub
+                # "usermodel.clientRoleMapping.clientId": args.client_name,
+            },
+        }
+    ],
+}
+output(f"Creating or updating scope {args.scope_name}", scope)
+scope_id = keycloak_admin.create_client_scope(scope, skip_exists=True)
+keycloak_admin.update_client_scope(scope_id, scope)
 
-    delay = 30
+# Add scope to client
+keycloak_admin.add_client_optional_client_scope(cid, scope_id, {})
 
-    args = parser.parse_args()
-    for r in range(args.retry):
-        try:
-            run(args)
-        except exceptions.KeycloakError as e:
-            print(f"ERROR: {repr(e)}")
-            if r == args.retry - 1:
-                raise
-            print(f"Retrying after {delay} s")
-            sleep(delay)
+# Assign users to roles
+# admin_role = keycloak_admin.get_client_role(cid, args.admin_role)
+# user_role = keycloak_admin.get_client_role(cid, args.user_role)
+admin_role = keycloak_admin.get_realm_role(args.admin_role)
+user_role = keycloak_admin.get_realm_role(args.user_role)
 
+admin_uid = keycloak_admin.get_user_id(args.keycloak_admin)
+output(
+    f"Assigning roles to admin {args.keycloak_admin} ({admin_uid})",
+    [admin_role, user_role],
+)
+# keycloak_admin.assign_client_role(admin_uid, cid, [admin_role, user_role])
+keycloak_admin.assign_realm_roles(admin_uid, [admin_role, user_role])
 
-if __name__ == "__main__":
-    main()
+user_uid = keycloak_admin.get_user_id(args.user)
+output(f"Assigning roles to user {args.user} ({user_uid})", user_role)
+# keycloak_admin.assign_client_role(user_uid, cid, [user_role])
+keycloak_admin.assign_realm_roles(user_uid, [user_role])

--- a/ci/ci-setup-keycloak.py
+++ b/ci/ci-setup-keycloak.py
@@ -73,7 +73,7 @@ jupyterhub_url = args.jupyterhub_url
 verify = args.verify
 if verify.lower() == "true":
     verify = True
-if verify.lower() == "false":
+elif verify.lower() == "false":
     verify = False
 
 keycloak_admin = KeycloakAdmin(

--- a/ci/create-ci-secrets.py
+++ b/ci/create-ci-secrets.py
@@ -27,6 +27,7 @@ Usage:
 """
 
 import base64
+import re
 import secrets
 import string
 import sys
@@ -47,13 +48,13 @@ class SecretGenerator:
     """Generates various types of secrets like passwords and hex keys."""
 
     @staticmethod
-    def generate_password(length: int = 16) -> str:
+    def generate_password(length: int) -> str:
         """Generate a random password."""
         alphabet = string.ascii_letters + string.digits
         return "".join(secrets.choice(alphabet) for _ in range(length))
 
     @staticmethod
-    def generate_hex_key(length: int = 32) -> str:
+    def generate_hex_key(length: int) -> str:
         """Generate a random hex key."""
         return secrets.token_hex(length)
 
@@ -129,24 +130,28 @@ class CISecretsManager:
                 raise
 
     def process_secret_value(self, value: Any, secret_name: str, key: str) -> str:
-        """Process a secret value, handling special generation patterns."""
-        if isinstance(value, str):
-            if value == "{{ generate_password }}":
-                generated = self.generator.generate_password()
-                self.generated_values[f"{secret_name}.{key}"] = generated
-                return generated
-            elif value == "{{ generate_hex_key }}":
-                generated = self.generator.generate_hex_key()
-                self.generated_values[f"{secret_name}.{key}"] = generated
-                return generated
-            elif value.startswith("{{ generate_password("):
-                # Extract length parameter
-                length_str = value.split("(")[1].split(")")[0]
-                length = int(length_str)
-                generated = self.generator.generate_password(length)
-                self.generated_values[f"{secret_name}.{key}"] = generated
-                return generated
-        return str(value)
+        """Process a secret value, handling special generation patterns of the form
+
+        {{ function_name optional-length }}
+        """
+        match = re.match(r"\{\{\s*(?P<method>\w+)(\s+(?P<length>\d+))?\s*\}\}", value)
+        if not match:
+            return value
+
+        method = match.group("method")
+        length = match.group("length")
+        if length:
+            length = int(length)
+
+        if method == "generate_password":
+            generated = self.generator.generate_password(length or 16)
+            self.generated_values[f"{secret_name}.{key}"] = generated
+            return generated
+        if method == "generate_hex_key":
+            generated = self.generator.generate_hex_key(length or 32)
+            self.generated_values[f"{secret_name}.{key}"] = generated
+            return generated
+        raise ValueError(f"Invalid generator method function: {method}")
 
     def check_secret_exists(self, secret_name: str) -> bool:
         """Check if a secret already exists in the namespace."""

--- a/ci/create-ci-secrets.py
+++ b/ci/create-ci-secrets.py
@@ -397,7 +397,7 @@ class CISecretsManager:
 
 
 def main(
-    context: Annotated[str, typer.Option(help="Kubernetes context to use")],
+    context: Annotated[str, typer.Option(help="Kubernetes context to use")] = "default",
     namespace: Annotated[
         str, typer.Option(help="Namespace to create secrets in (default: secret-store)")
     ] = "secret-store",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+cryptography==45.0.4
 kubernetes==32.0.1
 pytest==8.3.5
 python-keycloak==5.6.0

--- a/docs/development/k3s-dev.md
+++ b/docs/development/k3s-dev.md
@@ -197,13 +197,12 @@ kubectl get crd
 ```bash
 # Get the initial admin password
 KEYCLOAK_PASSWORD=$(kubectl -nkeycloak get secret keycloak-admin-secret -o jsonpath='{.data.admin-password}' | base64 -d)
-# Wait a minute to ensure Keycloak is actually ready
-sleep 1m
 
 ci/ci-setup-keycloak.py \
   --keycloak-admin=admin \
   --keycloak-password="$KEYCLOAK_PASSWORD" \
-  --verify=false
+  --verify=false \
+  --retry=5
 ```
 
 

--- a/docs/development/k3s-dev.md
+++ b/docs/development/k3s-dev.md
@@ -197,12 +197,13 @@ kubectl get crd
 ```bash
 # Get the initial admin password
 KEYCLOAK_PASSWORD=$(kubectl -nkeycloak get secret keycloak-admin-secret -o jsonpath='{.data.admin-password}' | base64 -d)
+# Wait a minute to ensure Keycloak is actually ready
+sleep 1m
 
 ci/ci-setup-keycloak.py \
   --keycloak-admin=admin \
   --keycloak-password="$KEYCLOAK_PASSWORD" \
-  --verify=false \
-  --retry=5
+  --verify=false
 ```
 
 

--- a/docs/development/k3s-dev.md
+++ b/docs/development/k3s-dev.md
@@ -196,10 +196,10 @@ kubectl get crd
 
 ```bash
 # Get the initial admin password
-KEYCLOAK_PASSWORD=$(kubectl -nkeycloak get secret keycloak -o jsonpath='{.data.admin-password}' | base64 -d)
+KEYCLOAK_PASSWORD=$(kubectl -nkeycloak get secret keycloak-admin-secret -o jsonpath='{.data.admin-password}' | base64 -d)
 
 ci/ci-setup-keycloak.py \
-  --keycloak-admin=user \
+  --keycloak-admin=admin \
   --keycloak-password="$KEYCLOAK_PASSWORD" \
   --verify=false
 ```

--- a/docs/development/k3s-dev.md
+++ b/docs/development/k3s-dev.md
@@ -197,6 +197,8 @@ kubectl get crd
 ```bash
 # Get the initial admin password
 KEYCLOAK_PASSWORD=$(kubectl -nkeycloak get secret keycloak-admin-secret -o jsonpath='{.data.admin-password}' | base64 -d)
+# Wait a minute to ensure Keycloak is actually ready
+sleep 1m
 
 ci/ci-setup-keycloak.py \
   --keycloak-admin=admin \

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -50,9 +50,19 @@ def test_web_ingress_jupyterhub():
     assert r.status_code == 302
     assert r.headers["Location"] == "/hub/"
 
-    # Which should redirect to /hub/login?next=%2Fhub%2F
+    # Which should redirect to /hub/home (JupyterHub.default_url)
     r = requests.get(
         f"https://{INGRESS_HOST}/hub/",
+        headers={"Host": JUPYTERHUB_HOST},
+        verify=False,
+        allow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert r.headers["Location"] == "/hub/home"
+
+    # Which should redirect to /hub/login?next=%2Fhub%2F
+    r = requests.get(
+        f"https://{INGRESS_HOST}/hub/home",
         headers={"Host": JUPYTERHUB_HOST},
         verify=False,
         allow_redirects=False,

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -19,6 +19,7 @@ def test_web_ingress_keycloak():
         verify=False,
         allow_redirects=False,
     )
+
     assert r.status_code == 302
     assert r.headers["Location"] == f"https://{KEYCLOAK_HOST}/admin/"
 
@@ -45,6 +46,7 @@ def test_web_ingress_jupyterhub():
         verify=False,
         allow_redirects=False,
     )
+
     assert r.status_code == 302
     assert r.headers["Location"] == "/hub/"
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,10 +1,14 @@
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.backends import default_backend
 import os
 import requests
-
+import ssl
+import socket
+import pytest
 
 INGRESS_HOST = os.getenv("INGRESS_HOST", "localhost")
-KEYCLOAK_HOST = os.getenv("KEYCLOAK_HOST", "keycloak.dev.k8tre.internal")
-JUPYTERHUB_HOST = os.getenv("JUPYTERHUB_HOST", "jupyter.dev.k8tre.internal")
+K8TRE_DOMAIN = os.getenv("K8TRE_DOMAIN", "dev.k8tre.internal")
 
 
 def test_web_ingress_keycloak():
@@ -12,6 +16,7 @@ def test_web_ingress_keycloak():
     Check that Keycloak is accessible via ingress
     """
 
+    KEYCLOAK_HOST = f"keycloak.{K8TRE_DOMAIN}"
     # Keycloak / should redirect to KEYCLOAK_HOST/admin/
     r = requests.get(
         f"https://{INGRESS_HOST}/",
@@ -39,6 +44,7 @@ def test_web_ingress_jupyterhub():
     Check that JupyterHub is accessible via ingress
     """
 
+    JUPYTERHUB_HOST = f"jupyter.{K8TRE_DOMAIN}"
     # JupyterHub / should redirect to /hub/
     r = requests.get(
         f"https://{INGRESS_HOST}/",
@@ -69,3 +75,49 @@ def test_web_ingress_jupyterhub():
     )
     assert r.status_code == 302
     assert r.headers["Location"].startswith("/hub/login")
+
+
+@pytest.mark.parametrize("subdomain", ["guacamole", "jupyter", "keycloak"])
+def test_ingress_certificates(subdomain):
+    """
+    Checking an ingress subdomain has the expected certificate
+    """
+    expected_hostname = f"{subdomain}.{K8TRE_DOMAIN}"
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    # Create a standard TCP socket, then wrap it with TLS and SNI
+    with socket.create_connection((INGRESS_HOST, 443)) as sock:
+        with ctx.wrap_socket(sock, server_hostname=expected_hostname) as ssl_sock:
+            # Extract domain name from the certificate
+            peer_cert_der = ssl_sock.getpeercert(binary_form=True)
+            assert peer_cert_der, "Server did not present a certificate"
+
+            cert = x509.load_der_x509_certificate(peer_cert_der, default_backend())
+
+            cn = None
+            for attribute in cert.subject:
+                if attribute.oid == NameOID.COMMON_NAME:
+                    cn = attribute.value
+                    break
+
+            san_names = []
+            try:
+                san_extension = cert.extensions.get_extension_for_class(
+                    x509.SubjectAlternativeName
+                )
+                for general_name in san_extension.value:
+                    if isinstance(general_name, x509.DNSName):
+                        san_names.append(general_name.value)
+            except x509.ExtensionNotFound:
+                pass
+
+            print(f"CN: {cn}")
+            print(f"SAN: {san_names}")
+
+            # Check the domain name
+            assert (cn and cn.lower() == expected_hostname.lower()) or (
+                expected_hostname.lower() in [name.lower() for name in san_names]
+            ), f"Domain name '{expected_hostname}' not in certificate."


### PR DESCRIPTION
This includes https://github.com/k8tre/k8tre/pull/39

This adds Apache Guacamole and a custom JupyterHub service that interacts with Guacamole. Everything is deployed in the `jupyterhub` namespace since Guacamole is tightly coupled, though it could be split into its own namespace.

All of the workspace configuration is done in `apps/jupyterhub/envs/dev/jupyterhub_extraconfig.py` with a dynamically generated `custom_options_form`. If we support this long term I think we should move this into a separate repo (e.g. `k8trespawner`) so we can ensure it is fully tested, and build a custom Z2JH hub image.