### PR TITLE
Patch appsets to ignore changes to syncpolicy and targetRevision

### DIFF
--- a/appsets/kustomization.yaml
+++ b/appsets/kustomization.yaml
@@ -14,3 +14,15 @@ resources:
   - identity/keycloak.yaml
   - workspaces/awms.yaml
   - workspaces/jupyterhub.yaml
+
+patches:
+# https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+  - target:
+      kind: ApplicationSet
+    patch: |-
+      - op: add
+        path: /spec/ignoreApplicationDifferences
+        value:
+          - jsonPointers:
+              - /spec/syncPolicy
+              - /spec/source/targetRevision


### PR DESCRIPTION
During development, developers should have the ability to temporarily turn off automatic sync and change the target branch for one or more apps. This PR addresses this need and is also related to #2 .

There is a risk that developers may do this on the production cluster and _forget_ to turn sync back on. We could address this by applying these patches only to the applications in the `dev` and `stg` cluster.

See https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync