### PR TITLE
Replace Keycloak bitnami chart with Keycloak operator

### DIFF
--- a/agnostics/nginx/k3s/envs/dev/values.yaml
+++ b/agnostics/nginx/k3s/envs/dev/values.yaml
@@ -5,7 +5,5 @@ controller:
     enabled: false
 
   # Use hostport for ingress so we don't need a LoadBalancer
-  hostPort:
-    enabled: true
   service:
-    type: ClusterIP
+    type: LoadBalancer

--- a/apps/jupyterhub/base/network_policy.yaml
+++ b/apps/jupyterhub/base/network_policy.yaml
@@ -49,17 +49,10 @@ metadata:
   namespace: jupyterhub
 spec:
   egress:
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: keycloak
-            app.kubernetes.io/component: keycloak
-            app.kubernetes.io/instance: keycloak
-            app.kubernetes.io/name: keycloak
-      toPorts:
-        - ports:
-            # This is the pod not the service port
-            - port: "8080"
-              protocol: TCP
+    - toServices:
+        - k8sService:
+            namespace: keycloak
+            serviceName: keycloak-service
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: jupyterhub

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -19,8 +19,8 @@ hub:
       oauth_callback_url: https://jupyter.dev.k8tre.internal/hub/oauth_callback
       authorize_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/auth
       # Internal to the cluster: svc=keycloak ns=keycloak
-      token_url: http://keycloak-service.keycloak/realms/master/protocol/openid-connect/token
-      userdata_url: http://keycloak-service.keycloak/realms/master/protocol/openid-connect/userinfo
+      token_url: http://keycloak-service.keycloak.svc.cluster.local/realms/master/protocol/openid-connect/token
+      userdata_url: http://keycloak-service.keycloak.svc.cluster.local/realms/master/protocol/openid-connect/userinfo
       scope:
         - openid
         # The custom scope name

--- a/apps/jupyterhub/envs/dev/values.yaml
+++ b/apps/jupyterhub/envs/dev/values.yaml
@@ -19,8 +19,8 @@ hub:
       oauth_callback_url: https://jupyter.dev.k8tre.internal/hub/oauth_callback
       authorize_url: https://keycloak.dev.k8tre.internal/realms/master/protocol/openid-connect/auth
       # Internal to the cluster: svc=keycloak ns=keycloak
-      token_url: http://keycloak.keycloak/realms/master/protocol/openid-connect/token
-      userdata_url: http://keycloak.keycloak/realms/master/protocol/openid-connect/userinfo
+      token_url: http://keycloak-service.keycloak/realms/master/protocol/openid-connect/token
+      userdata_url: http://keycloak-service.keycloak/realms/master/protocol/openid-connect/userinfo
       scope:
         - openid
         # The custom scope name

--- a/apps/keycloak/base/keycloak.yaml
+++ b/apps/keycloak/base/keycloak.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+spec:
+  instances: 1
+  db:
+    vendor: postgres
+    host: keycloak-postgres-cluster-rw
+    usernameSecret:
+      name: keycloak-db-secret
+      key: username
+    passwordSecret:
+      name: keycloak-db-secret
+      key: password
+  http:
+    tlsSecret: keycloak-k8tre-tls
+  hostname:
+    hostname: keycloak.dev.k8tre.internal
+  proxy:
+    headers: xforwarded
+  ingress:
+    className: nginx

--- a/apps/keycloak/base/kustomization.yaml
+++ b/apps/keycloak/base/kustomization.yaml
@@ -5,6 +5,13 @@ namespace: keycloak
 
 # See https://www.keycloak.org/operator/installation#_installing_multiple_operators
 resources:
+  # Operator CRDs
+  - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.4.0/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+  - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.4.0/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+  # Operator
+  - https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.4.0/kubernetes/kubernetes.yml
+  # Other resources
   - certificate.yaml
   - keycloak-admin-secret.yaml
   - keycloak-db-external-secret.yaml
+  - keycloak.yaml

--- a/apps/keycloak/envs/dev/kustomization.yaml
+++ b/apps/keycloak/envs/dev/kustomization.yaml
@@ -1,13 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-helmCharts:
-  - name: keycloak
-    repo: oci://registry-1.docker.io/bitnamicharts/
-    version: 24.7.4
-    releaseName: keycloak
-    namespace: keycloak
-    valuesFile: values.yaml
       
 resources:
   - ../../base

--- a/appsets/kustomization.yaml
+++ b/appsets/kustomization.yaml
@@ -14,3 +14,15 @@ resources:
   - identity/keycloak.yaml
   - workspaces/awms.yaml
   - workspaces/jupyterhub.yaml
+
+patches:
+# https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+  - target:
+      kind: ApplicationSet
+    patch: |-
+      - op: add
+        path: /spec/ignoreApplicationDifferences
+        value:
+          - jsonPointers:
+              - /spec/syncPolicy
+              - /spec/source/targetRevision


### PR DESCRIPTION
This is a draft PR at the moment because I can't get Jupyterhub to authenticate with the new Keycloak instance. 

The keycloak setup script runs successfully and I am able to log into keycloak admin portal. The client and users are successfully created.

However, clicking on the 'Signin with keycloak' button on JupyterHub, results in a `500 Internal Server Error` after some seconds. See error log below.

If I don't use the FQDN, I still get the error but this time it is a url not found error. The keycloak operator deploys a `statefulset` rather than a `deployment`. I have modified the Cilium Network Policy to allow access to the service rather than the pod. (The service is now called `keycloak-service` rather than just `keycloak`. I have inspected network traffic with Hubble and don't see any dropped traffic into the Keycloak namespace. It is 0130 in the morning and I am fairly confident that I have done something silly but can't quite figure out.

```bash
[E 2025-10-03 00:13:46.233 JupyterHub oauth2:857] Error fetching 599 POST http://keycloak-service.keycloak.svc.cluster.local/realms/master/protocol/openid-connect/token: HTTP 599: Connection timed out after 20000 milliseconds
[E 2025-10-03 00:13:46.234 JupyterHub web:1875] Uncaught exception GET /hub/oauth_callback?state=eyJzdGF0ZV9pZCI6ICI2MzM5MzcwZGVlYWY0YjQ5OGE2Zjc0OGE5MmNhYzMxMyJ9&session_state=6e1d6483-73b4-3d4a-b186-84cf9c4ba520&iss=https%3A%2F%2Fkeycloak.dev.k8tre.internal%2Frealms%2Fmaster&code=abf502fb-8f54-848b-0928-cc048ba340bf.6e1d6483-73b4-3d4a-b186-84cf9c4ba520.115cf1f2-1cdc-43dc-8633-bcd48cf07e40 (10.0.0.206)
    HTTPServerRequest(protocol='https', host='jupyter.dev.k8tre.internal', method='GET', uri='/hub/oauth_callback?state=eyJzdGF0ZV9pZCI6ICI2MzM5MzcwZGVlYWY0YjQ5OGE2Zjc0OGE5MmNhYzMxMyJ9&session_state=6e1d6483-73b4-3d4a-b186-84cf9c4ba520&iss=https%3A%2F%2Fkeycloak.dev.k8tre.internal%2Frealms%2Fmaster&code=abf502fb-8f54-848b-0928-cc048ba340bf.6e1d6483-73b4-3d4a-b186-84cf9c4ba520.115cf1f2-1cdc-43dc-8633-bcd48cf07e40', version='HTTP/1.1', remote_ip='10.0.0.206')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.12/site-packages/tornado/web.py", line 1790, in _execute
        result = await result
                 ^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/oauthenticator/oauth2.py", line 245, in get
        user = await self.login_user()
               ^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/jupyterhub/handlers/base.py", line 964, in login_user
        authenticated = await self.authenticate(data)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/jupyterhub/auth.py", line 695, in get_authenticated_user
        authenticated = await maybe_future(self.authenticate(handler, data))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/oauthenticator/oauth2.py", line 1316, in authenticate
        token_info = await self.get_token_info(handler, access_token_params)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/oauthenticator/oauth2.py", line 1092, in get_token_info
        token_info = await self.httpfetch(
                     ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/oauthenticator/oauth2.py", line 892, in httpfetch
        return await self.fetch(
               ^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.12/site-packages/oauthenticator/oauth2.py", line 858, in fetch
        raise e
      File "/usr/local/lib/python3.12/site-packages/oauthenticator/oauth2.py", line 837, in fetch
        resp = await self.http_client.fetch(req, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    tornado.curl_httpclient.CurlError: HTTP 599: Connection timed out after 20000 milliseconds
[D 2025-10-03 00:13:46.235 JupyterHub base:1542] Using default error template for 500
[E 2025-10-03 00:13:46.247 JupyterHub log:184] {
      "Cookie": "_xsrf=[secret]; jupyterhub-session-id=[secret]; oauthenticator-state=[secret]",
      "Priority": "u=0, i",
      "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
      "Accept-Encoding": "gzip, deflate, br, zstd",
      "Sec-Ch-Ua-Platform": "\"Linux\"",
      "Sec-Ch-Ua-Mobile": "?0",
      "Sec-Ch-Ua": "\"Google Chrome\";v=\"141\", \"Not?A_Brand\";v=\"8\", \"Chromium\";v=\"141\"",
      "Sec-Fetch-Dest": "document",
      "Sec-Fetch-User": "?1",
      "Sec-Fetch-Mode": "navigate",
      "Sec-Fetch-Site": "same-site",
      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
      "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
      "Upgrade-Insecure-Requests": "1",
      "Dnt": "1",
      "X-Scheme": "https",
      "X-Forwarded-Scheme": "https",
      "X-Forwarded-Proto": "https,http",
      "X-Forwarded-Port": "443,80",
      "X-Forwarded-Host": "jupyter.dev.k8tre.internal",
      "X-Forwarded-For": "10.0.0.206,::ffff:10.0.0.14",
      "X-Real-Ip": "10.0.0.206",
      "X-Request-Id": "3f07291f034497657a83003c73967d4d",
      "Host": "jupyter.dev.k8tre.internal",
      "Connection": "keep-alive"
    }
[E 2025-10-03 00:13:46.247 JupyterHub log:192] 500 GET /hub/oauth_callback?state=[secret]&session_state=[secret]&iss=https%3A%2F%2Fkeycloak.dev.k8tre.internal%2Frealms%2Fmaster&code=[secret] (@10.0.0.206) 20015.21ms
[D 2025-10-03 00:13:48.228 JupyterHub log:192] 200 GET /hub/health (@10.0.0.206) 0.66ms
```

This is related to #57.