### PR TITLE
Small updates to spec statements

### DIFF
--- a/docs/spec/byosoftware.md
+++ b/docs/spec/byosoftware.md
@@ -25,6 +25,8 @@ TREu is designed for a bring-your-own software model, encouraging researchers to
 
 FRIDGE extends the computational capability of another TRE by accepting tasks to run on the HPC platform where FRIDGE is deployed. Although adopting a job submission model, FRIDGE allows users to upload container images with their own software that is to be executed as a job.
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **What is K8TRE's stance on allowing researchers to ingress "bring-your-own software and code", versus a curated software model? Will it allow both?**

--- a/docs/spec/containerruntimes.md
+++ b/docs/spec/containerruntimes.md
@@ -20,6 +20,8 @@ In its default AWS adaptation, TREu uses the default high- and low-level contain
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **What container runtimes should a K8TRE implementation use, and why?**

--- a/docs/spec/database.md
+++ b/docs/spec/database.md
@@ -20,6 +20,8 @@ TREu uses Postgres databases for use in its System cluster, specifically, for Ap
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **What should K8TRE Specification say about *in-cluster* DBs and what should it say about *off-cluster* DBs?**

--- a/docs/spec/dns.md
+++ b/docs/spec/dns.md
@@ -22,6 +22,8 @@ In a TREu deployment, DNS records are not created by applications running on the
 
 FRIDGE conceptually follows a job execution model, whereby a frontend-TRE submits tasks to a FRIDGE instance and collects results through a well-known API. FRIDGE users may not deploy long running services for external consumption and, therefore, requires no external DNS support.  
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **What will provide in-cluster DNS?**

--- a/docs/spec/documentation.md
+++ b/docs/spec/documentation.md
@@ -27,6 +27,8 @@ TREu hosts a Docs site at https://docs.tre.arc.ucl.ac.uk/
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **Question**

--- a/docs/spec/gitops.md
+++ b/docs/spec/gitops.md
@@ -31,6 +31,8 @@ TREu deployments use GitOps [(e.g. for the ARC TRE, per ISMS guidance)](https://
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - Why is employing GitOps practices recommended?

--- a/docs/spec/identity.md
+++ b/docs/spec/identity.md
@@ -3,7 +3,7 @@ topic: Identity and Access
 last_updated: 2025-11-25
 discussion: 
 k8tre_statements:
-  spec: The TRE must implement identity and access management services to manage access to resources based on trusted identities. These services may be deployed on-cluster, or apps may connect to off-cluster identity services, for authentication and authorisation, with MFA enforced.
+  spec: The TRE must implement identity and access management services to manage user access to resources based on trusted identities. These services may be deployed on-cluster, or apps may connect to off-cluster identity services, for authentication and authorisation, with MFA enforced.
   satre:
     - ref: 1.5.3
       rationale: SATRE requires TRE operators to have a set of services to manage access to resources based on identity. K8TRE-compliant components or entire TREs must therefore provide access to resources based on identity.
@@ -27,8 +27,11 @@ TREu requires users to log into the TRE Portal using their standard UCL identity
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **Question**
 
    Answer
+

--- a/docs/spec/ingress.md
+++ b/docs/spec/ingress.md
@@ -20,6 +20,8 @@ TREu implements an NGINX Ingress Controller exposed to a AWS Network Load Balanc
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **Are load balancers mandatory for a K8TRE?**

--- a/docs/spec/networking.md
+++ b/docs/spec/networking.md
@@ -33,6 +33,8 @@ The (Kubernetes-based) System plane uses the Cilium CNI and network policies to 
 
 FRIDGE makes extensive use of Cilium and standard Kubernetes network policies to ensure only the required network paths are open between components in the cluster. This also applies to ingress and egress traffic. Project isolation is not required in FRIDGE as a FRIDGE instance is currently dedicated to a project.
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - **What capabilities must a CNI must provide the cluster to be K8TRE compliant?**

--- a/docs/spec/secrets.md
+++ b/docs/spec/secrets.md
@@ -21,6 +21,8 @@ The KMS provider and plugin is the preferred solution for MVP.
 
 ### FRIDGE
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - How do we store secrets in and make them available to applications on the cluster? Use k8s default secrets storage or more secure alternative backends?

--- a/docs/spec/storage.md
+++ b/docs/spec/storage.md
@@ -26,6 +26,8 @@ The TREu System plane cluster, which does not have access to sensitive data, use
 
 FRIDGE uses Longhorn for compatibility across different HPC platforms. FRIDGE also applies encryption on storage volumes attached to Kubernetes Pods where user jobs are exectuded, ensuring data safety.
 
+{{ satre_link(page.meta) }}
+
 ## FAQ
 
 - Which storage requirements shall the K8TRE Specification assume the underlying Kubernetes platform will provide? e.g. what storageClass definitions / providers should be recommended/mandated?

--- a/docs/spec/workspaces.md
+++ b/docs/spec/workspaces.md
@@ -1,5 +1,5 @@
 ---
-topic: Workspace Isolation
+topic: Workspaces
 last_updated: 2025-11-25
 discussion: 
 k8tre_statements:
@@ -26,6 +26,8 @@ k8tre_statements:
 In TREu, Projects are isolated from each other at the network level, preventing inter-project transfers. Different projects use separate file systems and are mounted exclusively into project desktops, available only to the users of that project. TREu does not currently support the provision of shared services within Projects.
 
 ### FRIDGE
+
+{{ satre_link(page.meta) }}
 
 ## FAQ
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,21 @@ def define_env(env):
         updated = meta.get("last_updated", "Unknown")
         source = meta.get("discussion") or "N/A"
 
+
+
+        return f"""
+# {topic}
+
+!!! abstract "Specification"
+    {statement}
+
+Last updated: {updated}  
+Source: {source}
+"""
+    
+    
+    @env.macro
+    def satre_link(meta):
         satre_items = meta.get("k8tre_statements", {}).get("satre", [])
 
         # Build SATRE section only if items exist
@@ -19,15 +34,4 @@ def define_env(env):
 **Component {ref}**  
 {rationale}
 """
-
-        return f"""
-# {topic}
-
-!!! abstract "Specification"
-    {statement}
-
-Last updated: {updated}  
-Source: {source}
-
-{satre_md}
-"""
+                return satre_md


### PR DESCRIPTION
Following comments from the team

- Put the section on satre linkage below Implementation Compliance section 
- Plus rename workspaceisolation -> workspaces
- Make identity spec statement specific to user access