### PR TITLE
Active Directory changes

### DIFF
--- a/agnostics/ad/base/ad-service.yaml
+++ b/agnostics/ad/base/ad-service.yaml
@@ -61,7 +61,7 @@ spec:
       labels:
         app: samba
       annotations:
-        external-dns.alpha.kubernetes.io/internal-hostname: "dc0.ad.${DOMAIN}"
+        external-dns.alpha.kubernetes.io/internal-hostname: "dc0.ad.${DOMAIN},dc0.${DOMAIN}"
         external-dns.alpha.kubernetes.io/access: private
     spec:
       hostname: dc0

--- a/agnostics/ad/base/ad-service.yaml
+++ b/agnostics/ad/base/ad-service.yaml
@@ -104,6 +104,11 @@ spec:
             - name: samba-init
               mountPath: /samba-health.sh
               subPath: samba-health.sh
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             capabilities:
               add:

--- a/agnostics/ad/base/keytab-job.sh
+++ b/agnostics/ad/base/keytab-job.sh
@@ -15,32 +15,32 @@ echo "    REALM: $REALM"
 
 mkdir /samba/etc
 cat > /etc/samba/smb.conf <<CONF
-    [global]
-        tls verify peer = no_check
+[global]
+    tls verify peer = no_check
 CONF
 
     cat > /config <<CONF
-    [libdefaults]
-    default_realm = $REALM
-    kdc_timesync = 1
-    ccache_type = 4
-    forwardable = true
-    proxiable = true
-    dns_lookup_kdc = false
-    dns_lookup_realm = false
+[libdefaults]
+default_realm = $REALM
+kdc_timesync = 1
+ccache_type = 4
+forwardable = true
+proxiable = true
+dns_lookup_kdc = false
+dns_lookup_realm = false
 
-        [realms]
-    $REALM = {
-      kdc = DC0.$REALM
-    }
+    [realms]
+$REALM = {
+  kdc = DC0.$REALM
+}
 
-    [domain_realm]
-    .$REALM = $REALM
-    .$realm = $REALM
-    ad = $REALM
-    AD = $REALM
-    .ad = $REALM
-    .AD = $REALM
+[domain_realm]
+.$REALM = $REALM
+.$realm = $REALM
+ad = $REALM
+AD = $REALM
+.ad = $REALM
+.AD = $REALM
 CONF
 
 kubectl -n ad create configmap "krb5.conf" --from-file /config -o yaml --dry-run=client | kubectl apply -f -

--- a/agnostics/ad/base/keytab-job.sh
+++ b/agnostics/ad/base/keytab-job.sh
@@ -29,7 +29,7 @@ proxiable = true
 dns_lookup_kdc = false
 dns_lookup_realm = false
 
-    [realms]
+[realms]
 $REALM = {
   kdc = DC0.$REALM
 }

--- a/agnostics/ad/base/keytab-job.sh
+++ b/agnostics/ad/base/keytab-job.sh
@@ -43,7 +43,7 @@ AD = $REALM
 .AD = $REALM
 CONF
 
-kubectl -n ad create configmap "krb5.conf" --from-file /config -o yaml --dry-run=client | kubectl apply -f -
+kubectl -n "$NAMESPACE" create configmap "krb5.conf" --from-file /config -o yaml --dry-run=client | kubectl apply -f -
 cp /config /etc/krb5.conf
 
 kinit -k -t /Administrator.keytab -c Administrator.ccache "Administrator@$REALM"

--- a/agnostics/ad/base/keytab-job.yaml
+++ b/agnostics/ad/base/keytab-job.yaml
@@ -97,3 +97,8 @@ spec:
                 subPath: keytab-job.sh
             command:
               - /keytab-job.sh
+            env:
+              - name: NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace

--- a/agnostics/ad/base/samba-start.sh
+++ b/agnostics/ad/base/samba-start.sh
@@ -66,8 +66,8 @@ samba-tool dns add dc0 10.in-addr.arpa $MYRIP PTR dc0.$REALM --use-krb5-ccache=/
 ######################################################################
 # Allow customisations.  Find all ConfigMaps prefixed with
 # `custom-samba-start-` and source them.
-kubectl -n ad get configmap -o yaml | \
+kubectl -n "$NAMESPACE" get configmap -o yaml | \
     yq '.items[] | select(.metadata.name | test("custom-samba-start-")) | .metadata.name' | \
     while read cmName ; do
-	source <( kubectl -n ad get configmap "$cmName" -o jsonpath='{.data.*}')
+	source <( kubectl -n "$NAMESPACE" get configmap "$cmName" -o jsonpath='{.data.*}')
     done

--- a/agnostics/ad/base/samba-start.sh
+++ b/agnostics/ad/base/samba-start.sh
@@ -62,3 +62,12 @@ samba-tool dns add dc0 $REALM '.' a $MYIP --use-krb5-ccache=/ccache || true
 
 MYRIP=$(echo $MYIP | awk -F. '{ print $4"."$3"."$2 }')
 samba-tool dns add dc0 10.in-addr.arpa $MYRIP PTR dc0.$REALM --use-krb5-ccache=/ccache
+
+######################################################################
+# Allow customisations.  Find all ConfigMaps prefixed with
+# `custom-samba-start-` and source them.
+kubectl -n ad get configmap -o yaml | \
+    yq '.items[] | select(.metadata.name | test("custom-samba-start-")) | .metadata.name' | \
+    while read cmName ; do
+	source <( kubectl -n ad get configmap "$cmName" -o jsonpath='{.data.*}')
+    done


### PR DESCRIPTION
* Allow customisation of Samba deployment through additional ConfigMaps prefixed with `custom-samba-start-`. In HIC we'll be using this to create the SPNs for MSSQL, and export the MSSQL user keytab, which has to be done locally on a Samba domain controller.
* Removed indentation on krb5.conf and smb.conf. MSSQL refuses to parse the parameters from krb5.conf if they are indented. This was quite an annoying realisation.
* Added a second internal-hostname to dc0, so that it will exist in `${DOMAIN}` and `ad.${DOMAIN}`. This allows the non-ad domain to be used as a glue record for zone delegation.